### PR TITLE
SF-1202: Prevent GitHub pages from ignoring files with leading underscores

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "tslint-config-prettier": "^1.13.0",
     "typedoc": "^0.13.0",
     "typedoc-plugin-monorepo": "github:groupby/typedoc-plugin-monorepo",
+    "typedoc-plugin-nojekyll": "^1.0.1",
     "typescript": "^3.1.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1612,6 +1612,15 @@ from@^0.1.7:
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
   integrity sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=
 
+fs-extra@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
+  integrity sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.0.tgz#8cc3f47ce07ef7b3593a11b9fb245f7e34c041d6"
@@ -4319,6 +4328,13 @@ typedoc-default-themes@^0.5.0:
   dependencies:
     highlight.js "^9.12.0"
     marked "^0.3.19"
+
+typedoc-plugin-nojekyll@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-nojekyll/-/typedoc-plugin-nojekyll-1.0.1.tgz#d6879d4118bbf10efe3feb3b766b69a09c80b3ef"
+  integrity sha512-hdFMhn0vAFCwepihSaVVs5yyImjo2FCX/OVQW89lrrqoARYHlAchOki4BQug23UqFSrYdykUu8yP4gD0M48qbw==
+  dependencies:
+    fs-extra "^6.0.1"
 
 typedoc@^0.13.0:
   version "0.13.0"


### PR DESCRIPTION
The typedoc plugin nojekyll adds a  .nojekyll  folder to the docs output
directory. This file will tell GitHub pages that this is not a Jekyll
site and will not process the files with Jekyll, which will cause the
underscore files to be rendered.