### PR TITLE
SF-1228: Fix module names for better automated documentation

### DIFF
--- a/packages/@storefront/flux-capacitor/package.json
+++ b/packages/@storefront/flux-capacitor/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@types/redux-logger": "^3.0.0",
+    "@types/redux-persist": "^4.3.1",
     "cuid": "^1.3.8",
     "eventemitter3": "^3.0.0",
     "fetch-ponyfill": "^4.1.0",

--- a/packages/@storefront/flux-capacitor/package.json
+++ b/packages/@storefront/flux-capacitor/package.json
@@ -47,7 +47,6 @@
   },
   "dependencies": {
     "@types/redux-logger": "^3.0.0",
-    "@types/redux-persist": "^4.3.1",
     "cuid": "^1.3.8",
     "eventemitter3": "^3.0.0",
     "fetch-ponyfill": "^4.1.0",

--- a/packages/@storefront/flux-capacitor/src/core/actions/creators.ts
+++ b/packages/@storefront/flux-capacitor/src/core/actions/creators.ts
@@ -1,4 +1,4 @@
-import { Record, Results, Template } from 'groupby-api';
+import { Results } from 'groupby-api';
 import Actions from '.';
 import PageAdapter from '../adapters/page';
 import SearchAdapter from '../adapters/search';
@@ -715,7 +715,7 @@ namespace ActionCreators {
    * @return {Actions.ReceiveMoreProducts}          - Action with products.
    */
   export function receiveMoreProducts(res: Results) {
-    return (state: Store.State): Actions.ReceiveMoreProducts => {
+    return (_: Store.State): Actions.ReceiveMoreProducts => {
       // tslint:disable-next-line max-line-length
       return handleError(createAction(Actions.RECEIVE_MORE_PRODUCTS, res), () => createAction(Actions.RECEIVE_MORE_PRODUCTS, SearchAdapter.augmentProducts(res)));
     };
@@ -727,7 +727,7 @@ namespace ActionCreators {
    * @return {Actions.ReceiveAutocompleteProducts}     - Action and res.
    */
   export function receiveAutocompleteProducts(res: Results) {
-    return (state: Store.State): Actions.Action<string, any>[] | Actions.ReceiveAutocompleteProducts => {
+    return (_: Store.State): Actions.Action<string, any>[] | Actions.ReceiveAutocompleteProducts => {
       const receiveProductsAction = createAction(Actions.RECEIVE_AUTOCOMPLETE_PRODUCTS, res);
 
       return handleError(receiveProductsAction, () => [
@@ -809,7 +809,7 @@ namespace ActionCreators {
   }
 
   export function receiveMorePastPurchaseProducts(res: Results) {
-    return (state: Store.State): Actions.ReceiveMorePastPurchaseProducts => {
+    return (_: Store.State): Actions.ReceiveMorePastPurchaseProducts => {
       // tslint:disable-next-line max-line-length
       return handleError(createAction(Actions.RECEIVE_MORE_PAST_PURCHASE_PRODUCTS, res), () => createAction(Actions.RECEIVE_MORE_PAST_PURCHASE_PRODUCTS, SearchAdapter.augmentProducts(res)));
     };

--- a/packages/@storefront/flux-capacitor/src/core/actions/creators.ts
+++ b/packages/@storefront/flux-capacitor/src/core/actions/creators.ts
@@ -715,7 +715,7 @@ namespace ActionCreators {
    * @return {Actions.ReceiveMoreProducts}          - Action with products.
    */
   export function receiveMoreProducts(res: Results) {
-    return (_: Store.State): Actions.ReceiveMoreProducts => {
+    return (state: Store.State): Actions.ReceiveMoreProducts => {
       // tslint:disable-next-line max-line-length
       return handleError(createAction(Actions.RECEIVE_MORE_PRODUCTS, res), () => createAction(Actions.RECEIVE_MORE_PRODUCTS, SearchAdapter.augmentProducts(res)));
     };
@@ -727,7 +727,7 @@ namespace ActionCreators {
    * @return {Actions.ReceiveAutocompleteProducts}     - Action and res.
    */
   export function receiveAutocompleteProducts(res: Results) {
-    return (_: Store.State): Actions.Action<string, any>[] | Actions.ReceiveAutocompleteProducts => {
+    return (state: Store.State): Actions.Action<string, any>[] | Actions.ReceiveAutocompleteProducts => {
       const receiveProductsAction = createAction(Actions.RECEIVE_AUTOCOMPLETE_PRODUCTS, res);
 
       return handleError(receiveProductsAction, () => [
@@ -809,7 +809,7 @@ namespace ActionCreators {
   }
 
   export function receiveMorePastPurchaseProducts(res: Results) {
-    return (_: Store.State): Actions.ReceiveMorePastPurchaseProducts => {
+    return (state: Store.State): Actions.ReceiveMorePastPurchaseProducts => {
       // tslint:disable-next-line max-line-length
       return handleError(createAction(Actions.RECEIVE_MORE_PAST_PURCHASE_PRODUCTS, res), () => createAction(Actions.RECEIVE_MORE_PAST_PURCHASE_PRODUCTS, SearchAdapter.augmentProducts(res)));
     };

--- a/packages/@storefront/flux-capacitor/src/core/actions/utils.ts
+++ b/packages/@storefront/flux-capacitor/src/core/actions/utils.ts
@@ -1,4 +1,3 @@
-import { Dispatch } from 'redux';
 import Actions from '.';
 import SearchAdapter from '../adapters/search';
 import Selectors from '../selectors';

--- a/packages/@storefront/flux-capacitor/src/core/actions/validators.ts
+++ b/packages/@storefront/flux-capacitor/src/core/actions/validators.ts
@@ -31,7 +31,6 @@ export const isValueRefinement: Validator<Actions.Payload.Navigation.AddRefineme
 export const isRefinementDeselectedByValue: Validator<Actions.Payload.Navigation.AddRefinement> = {
   func: (payload, state) => {
     const navigation = Selectors.navigation(state, payload.navigationId);
-    // tslint:disable-next-line max-line-length
     return !navigation || navigation.selected
     // tslint:disable-next-line max-line-length
       .findIndex((index) => SearchAdapter.refinementsMatch(<any>payload, <any>navigation.refinements[index], navigation.range ? 'Range' : 'Value')) === -1;

--- a/packages/@storefront/flux-capacitor/src/core/actions/validators.ts
+++ b/packages/@storefront/flux-capacitor/src/core/actions/validators.ts
@@ -33,6 +33,7 @@ export const isRefinementDeselectedByValue: Validator<Actions.Payload.Navigation
     const navigation = Selectors.navigation(state, payload.navigationId);
     // tslint:disable-next-line max-line-length
     return !navigation || navigation.selected
+    // tslint:disable-next-line max-line-length
       .findIndex((index) => SearchAdapter.refinementsMatch(<any>payload, <any>navigation.refinements[index], navigation.range ? 'Range' : 'Value')) === -1;
   },
   msg: 'refinement is already selected'

--- a/packages/@storefront/flux-capacitor/src/core/adapters/autocomplete.ts
+++ b/packages/@storefront/flux-capacitor/src/core/adapters/autocomplete.ts
@@ -4,33 +4,33 @@ import { RecommendationsResponse } from '../types';
 import Config from './configuration';
 import Search from './search';
 
-namespace Adapter {
+namespace AutocompleteAdapter {
 
   export const extractLanguage = (config: Configuration) =>
     Config.extractAutocompleteLanguage(config) || Config.extractLanguage(config);
 
   export const extractProductLanguage = (config: Configuration) =>
-    Config.extractAutocompleteProductLanguage(config) || Adapter.extractLanguage(config);
+    Config.extractAutocompleteProductLanguage(config) || AutocompleteAdapter.extractLanguage(config);
 
   export const extractArea = (config: Configuration) =>
     Config.extractAutocompleteArea(config) || Config.extractArea(config);
 
   export const extractProductArea = (config: Configuration) =>
-    Config.extractAutocompleteProductArea(config) || Adapter.extractArea(config);
+    Config.extractAutocompleteProductArea(config) || AutocompleteAdapter.extractArea(config);
 
   // tslint:disable-next-line max-line-length
   export const extractSuggestions = ({ result }: any, query: string, category: string, labels: { [key: string]: string }, config: Configuration): Actions.Payload.Autocomplete.Suggestions => {
 
     const searchTerms = result.searchTerms || [];
     const navigations = result.navigations || [];
-    let hasCategory = category && searchTerms[0] && Adapter.termsMatch(searchTerms[0].value, query);
+    let hasCategory = category && searchTerms[0] && AutocompleteAdapter.termsMatch(searchTerms[0].value, query);
     let categoryValues = hasCategory
-      ? [{ matchAll: true }, ...Adapter.extractCategoryValues(searchTerms[0], category)]
+      ? [{ matchAll: true }, ...AutocompleteAdapter.extractCategoryValues(searchTerms[0], category)]
       : [];
     if ( Config.extractSaytCategoriesForFirstMatch(config) ) {
       hasCategory = category && searchTerms[0];
       categoryValues = (hasCategory && searchTerms[0].additionalInfo)
-        ? [{ matchAll: true }, ...Adapter.extractCategoryValues(searchTerms[0], category)]
+        ? [{ matchAll: true }, ...AutocompleteAdapter.extractCategoryValues(searchTerms[0], category)]
         : [{ matchAll: true }];
     }
     // tslint:disable-next-line max-line-length
@@ -57,4 +57,4 @@ namespace Adapter {
   };
 }
 
-export default Adapter;
+export default AutocompleteAdapter;

--- a/packages/@storefront/flux-capacitor/src/core/adapters/autocomplete.ts
+++ b/packages/@storefront/flux-capacitor/src/core/adapters/autocomplete.ts
@@ -2,7 +2,6 @@ import Actions from '../actions';
 import Configuration from '../configuration';
 import { RecommendationsResponse } from '../types';
 import Config from './configuration';
-import Search from './search';
 
 namespace AutocompleteAdapter {
 

--- a/packages/@storefront/flux-capacitor/src/core/adapters/configuration.ts
+++ b/packages/@storefront/flux-capacitor/src/core/adapters/configuration.ts
@@ -1,5 +1,4 @@
 import { Request } from 'groupby-api';
-import { AutocompleteConfig, ProductSearchConfig } from 'sayt';
 import RecommendationsAdapter from '../adapters/recommendations';
 import Configuration from '../configuration';
 import * as AreaReducer from '../reducers/data/area';
@@ -221,6 +220,7 @@ namespace ConfigurationAdapter {
   export const recommendationsProductsOverrides: Override<Request> = (config) =>
     normalizeToFunction(config.recommendations.overrides.products);
 
+  // tslint:disable-next-line max-line-length
   export const recommendationsSuggestionsOverrides: Override<RecommendationsAdapter.Request & { query: string }> = (config) =>
     normalizeToFunction(config.recommendations.overrides.autocompleteSuggestions);
 }

--- a/packages/@storefront/flux-capacitor/src/core/adapters/configuration.ts
+++ b/packages/@storefront/flux-capacitor/src/core/adapters/configuration.ts
@@ -1,6 +1,6 @@
 import { Request } from 'groupby-api';
 import { AutocompleteConfig, ProductSearchConfig } from 'sayt';
-import Recommendations from '../adapters/recommendations';
+import RecommendationsAdapter from '../adapters/recommendations';
 import Configuration from '../configuration';
 import * as AreaReducer from '../reducers/data/area';
 import * as AutocompleteReducer from '../reducers/data/autocomplete';
@@ -10,32 +10,32 @@ import * as PastPurchaseReducer from '../reducers/data/past-purchases';
 import Store from '../store';
 import { normalizeToFunction, GenericTransformer } from '../utils';
 
-namespace Adapter {
+namespace ConfigurationAdapter {
 
   export const initialState = (config: Configuration): Partial<Store.State> =>
     ({
       data: <any>{
         present: {
-          area: Adapter.extractArea(config, AreaReducer.DEFAULT_AREA),
+          area: ConfigurationAdapter.extractArea(config, AreaReducer.DEFAULT_AREA),
           autocomplete: {
             ...AutocompleteReducer.DEFAULTS,
             category: {
               ...AutocompleteReducer.DEFAULTS.category,
-              field: Adapter.extractSaytCategoryField(config),
+              field: ConfigurationAdapter.extractSaytCategoryField(config),
             },
           },
-          fields: Adapter.extractFields(config),
-          collections: Adapter.extractCollections(config, CollectionsReducer.DEFAULT_COLLECTION),
-          sorts: Adapter.extractSorts(config),
+          fields: ConfigurationAdapter.extractFields(config),
+          collections: ConfigurationAdapter.extractCollections(config, CollectionsReducer.DEFAULT_COLLECTION),
+          sorts: ConfigurationAdapter.extractSorts(config),
           page: {
             ...PageReducer.DEFAULTS,
-            sizes: Adapter.extractPageSizes(config, PageReducer.DEFAULT_PAGE_SIZE)
+            sizes: ConfigurationAdapter.extractPageSizes(config, PageReducer.DEFAULT_PAGE_SIZE)
           },
           pastPurchases: {
             ...PastPurchaseReducer.DEFAULTS,
             page: {
               ...PastPurchaseReducer.DEFAULTS.page,
-              sizes: Adapter.extractPageSizes(config, PastPurchaseReducer.DEFAULT_PAGE_SIZE)
+              sizes: ConfigurationAdapter.extractPageSizes(config, PastPurchaseReducer.DEFAULT_PAGE_SIZE)
             }
           }
         }
@@ -101,7 +101,7 @@ namespace Adapter {
 
   // tslint:disable-next-line max-line-length
   export const extractCollections = (config: Configuration, defaultValue: string): Store.Indexed.Selectable<Store.Collection> => {
-    const { selected, allIds } = Adapter.extractIndexedState(config.collection || defaultValue);
+    const { selected, allIds } = ConfigurationAdapter.extractIndexedState(config.collection || defaultValue);
 
     return {
       selected,
@@ -212,17 +212,17 @@ namespace Adapter {
   export const pastPurchaseOverrides: Override<Request> = (config) =>
     normalizeToFunction(config.recommendations.pastPurchases.overrides.products);
 
-  export const recommendationsNavigationsOverrides: Override<Recommendations.RecommendationsBody> = (config) =>
+  export const recommendationsNavigationsOverrides: Override<RecommendationsAdapter.RecommendationsBody> = (config) =>
     normalizeToFunction(config.recommendations.overrides.navigations);
 
-  export const recommendationsIdsOverrides: Override<Recommendations.RecommendationsRequest> = (config) =>
+  export const recommendationsIdsOverrides: Override<RecommendationsAdapter.RecommendationsRequest> = (config) =>
     normalizeToFunction(config.recommendations.overrides.ids);
 
   export const recommendationsProductsOverrides: Override<Request> = (config) =>
     normalizeToFunction(config.recommendations.overrides.products);
 
-  export const recommendationsSuggestionsOverrides: Override<Recommendations.Request & { query: string }> = (config) =>
+  export const recommendationsSuggestionsOverrides: Override<RecommendationsAdapter.Request & { query: string }> = (config) =>
     normalizeToFunction(config.recommendations.overrides.autocompleteSuggestions);
 }
 
-export default Adapter;
+export default ConfigurationAdapter;

--- a/packages/@storefront/flux-capacitor/src/core/adapters/index.ts
+++ b/packages/@storefront/flux-capacitor/src/core/adapters/index.ts
@@ -1,8 +1,8 @@
 import Autocomplete from './autocomplete';
 import Configuration from './configuration';
-import Page from './page';
+import PageAdapter from './page';
 import Refinements from './refinements';
 import Request from './request';
 import Search from './search';
 
-export default { Autocomplete, Configuration, Page, Search, Refinements, Request };
+export default { Autocomplete, Configuration, PageAdapter, Search, Refinements, Request };

--- a/packages/@storefront/flux-capacitor/src/core/adapters/page.ts
+++ b/packages/@storefront/flux-capacitor/src/core/adapters/page.ts
@@ -1,4 +1,4 @@
-namespace Page {
+namespace PageAdapter {
   export const currentPage = (skip: number, pageSize: number) =>
     (skip / pageSize) + 1;
 
@@ -19,4 +19,4 @@ namespace Page {
   };
 }
 
-export default Page;
+export default PageAdapter;

--- a/packages/@storefront/flux-capacitor/src/core/adapters/past-purchases.ts
+++ b/packages/@storefront/flux-capacitor/src/core/adapters/past-purchases.ts
@@ -1,7 +1,7 @@
 import Selectors from '../selectors';
 import Store from '../store';
 
-namespace PastPurchases {
+namespace PastPurchasesAdapter {
 
   export const buildUrl = (customerId: string, endpoint: string) =>
     `https://${customerId}.groupbycloud.com/orders/v1/public/skus/${endpoint}`;
@@ -33,4 +33,4 @@ namespace PastPurchases {
   };
 }
 
-export default PastPurchases;
+export default PastPurchasesAdapter;

--- a/packages/@storefront/flux-capacitor/src/core/adapters/personalization.ts
+++ b/packages/@storefront/flux-capacitor/src/core/adapters/personalization.ts
@@ -45,7 +45,7 @@ namespace PersonalizationAdapter {
   export const generateNewBias = () => ({ lastUsed: Math.floor(Date.now() / 1000) });
 
   // tslint:disable-next-line max-line-length
-  export const transformToBrowser = (state: Store.Personalization.Biasing, reducerKey: string): BrowserStorageState => ({
+  export const transformToBrowser = (state: Store.Personalization.Biasing, _: string): BrowserStorageState => ({
     allIds: state.allIds.map(({ field, value }) => ({
       field,
       value,

--- a/packages/@storefront/flux-capacitor/src/core/adapters/personalization.ts
+++ b/packages/@storefront/flux-capacitor/src/core/adapters/personalization.ts
@@ -45,7 +45,7 @@ namespace PersonalizationAdapter {
   export const generateNewBias = () => ({ lastUsed: Math.floor(Date.now() / 1000) });
 
   // tslint:disable-next-line max-line-length
-  export const transformToBrowser = (state: Store.Personalization.Biasing, _: string): BrowserStorageState => ({
+  export const transformToBrowser = (state: Store.Personalization.Biasing, reducerKey: string): BrowserStorageState => ({
     allIds: state.allIds.map(({ field, value }) => ({
       field,
       value,

--- a/packages/@storefront/flux-capacitor/src/core/adapters/personalization.ts
+++ b/packages/@storefront/flux-capacitor/src/core/adapters/personalization.ts
@@ -5,7 +5,7 @@ import Selectors from '../selectors';
 import Store from '../store';
 import ConfigAdapter from './configuration';
 
-namespace Personalization {
+namespace PersonalizationAdapter {
   type ExtractableAction = Actions.SelectRefinement & Actions.AddRefinement;
 
   export const DAYS_IN_SECONDS = 86400;
@@ -117,4 +117,4 @@ namespace Personalization {
   export interface BrowserBiasKey extends Store.Personalization.BiasKey, Store.Personalization.SingleBias { }
 }
 
-export default Personalization;
+export default PersonalizationAdapter;

--- a/packages/@storefront/flux-capacitor/src/core/adapters/recommendations.ts
+++ b/packages/@storefront/flux-capacitor/src/core/adapters/recommendations.ts
@@ -5,7 +5,7 @@ import Store from '../store';
 import { sortBasedOn } from '../utils';
 import ConfigurationAdapter from './configuration';
 
-namespace Recommendations {
+namespace RecommendationsAdapter {
 
   export const buildUrl = (customerId: string, endpoint: string, mode: string) =>
     `https://${customerId}.groupbycloud.com/wisdom/v2/public/recommendations/${endpoint}/_get${mode}`;
@@ -124,4 +124,4 @@ namespace Recommendations {
   }
 }
 
-export default Recommendations;
+export default RecommendationsAdapter;

--- a/packages/@storefront/flux-capacitor/src/core/adapters/refinements.ts
+++ b/packages/@storefront/flux-capacitor/src/core/adapters/refinements.ts
@@ -3,7 +3,7 @@ import Selectors from '../selectors';
 import Store from '../store';
 import Search from './search';
 
-namespace Adapter {
+namespace RefinementsAdapter {
 
   // tslint:disable-next-line max-line-length
   export const mergeRefinements = ({ navigation: { name: navigationId, refinements: original } }: RefinementResults, state: Store.State) => {
@@ -25,4 +25,4 @@ namespace Adapter {
   };
 }
 
-export default Adapter;
+export default RefinementsAdapter;

--- a/packages/@storefront/flux-capacitor/src/core/adapters/request.ts
+++ b/packages/@storefront/flux-capacitor/src/core/adapters/request.ts
@@ -2,9 +2,9 @@ import { SelectedRefinement, Sort } from 'groupby-api';
 import Store from '../store';
 import { MAX_RECORDS } from './search';
 
-namespace Adapter {
+namespace RequestAdapter {
   export const clampPageSize = (page: number, pageSize: number): number =>
-    Math.min(pageSize, MAX_RECORDS - Adapter.extractSkip(page, pageSize));
+    Math.min(pageSize, MAX_RECORDS - RequestAdapter.extractSkip(page, pageSize));
 
   export const extractSkip = (page: number, pageSize: number): number =>
     (page - 1) * pageSize;
@@ -19,4 +19,4 @@ namespace Adapter {
       : { navigationName: field, type: 'Range', high: (<Store.RangeRefinement>refinement).high, low: (<Store.RangeRefinement>refinement).low };
 }
 
-export default Adapter;
+export default RequestAdapter;

--- a/packages/@storefront/flux-capacitor/src/core/adapters/search.ts
+++ b/packages/@storefront/flux-capacitor/src/core/adapters/search.ts
@@ -1,6 +1,5 @@
 import {
   Navigation,
-  PageInfo,
   RangeRefinement,
   Record,
   Refinement,
@@ -14,7 +13,6 @@ import {
   Zone,
 } from 'groupby-api';
 import Actions from '../actions';
-import Configuration from '../configuration';
 import Selectors from '../selectors';
 import Store from '../store';
 import ConfigAdapter from './configuration';

--- a/packages/@storefront/flux-capacitor/src/core/adapters/search.ts
+++ b/packages/@storefront/flux-capacitor/src/core/adapters/search.ts
@@ -18,11 +18,11 @@ import Configuration from '../configuration';
 import Selectors from '../selectors';
 import Store from '../store';
 import ConfigAdapter from './configuration';
-import Page from './page';
+import PageAdapter from './page';
 
 export const MAX_RECORDS = 10000;
 
-namespace Adapter {
+namespace SearchAdapter {
 
   // tslint:disable-next-line max-line-length
   export const extractQuery = ({ correctedQuery: corrected, didYouMean, originalQuery: original, relatedQueries: related, rewrites }: Results): Actions.Payload.Query =>
@@ -50,9 +50,9 @@ namespace Adapter {
     range: !!navigation.range,
     max: navigation.max,
     min: navigation.min,
-    refinements: navigation.refinements.map(Adapter.extractRefinement),
+    refinements: navigation.refinements.map(SearchAdapter.extractRefinement),
     selected: [],
-    sort: navigation.sort && Adapter.extractNavigationSort(navigation.sort),
+    sort: navigation.sort && SearchAdapter.extractNavigationSort(navigation.sort),
     metadata: navigation.metadata
       .reduce((metadata, keyValue) => Object.assign(metadata, { [keyValue.key]: keyValue.value }), {}),
   });
@@ -72,7 +72,7 @@ namespace Adapter {
 
     selected.refinements.forEach((refinement: Refinement) => {
       const index = available.refinements.findIndex((availableRef) =>
-        Adapter.refinementsMatch(availableRef, refinement));
+        SearchAdapter.refinementsMatch(availableRef, refinement));
 
       if (index !== -1) {
         available.selected.push(index);
@@ -127,7 +127,7 @@ namespace Adapter {
   // tslint:disable-next-line max-line-length
   export const combineNavigations = ({ availableNavigation: available, selectedNavigation: selected }: Results): Store.Navigation[] => {
     let navigations = available.reduce((map, navigation) =>
-      Object.assign(map, { [navigation.name]: Adapter.extractNavigation(navigation) }), {});
+      Object.assign(map, { [navigation.name]: SearchAdapter.extractNavigation(navigation) }), {});
 
     const filteredNavigations = filterNavigations(selected);
 
@@ -135,9 +135,9 @@ namespace Adapter {
       const availableNav = navigations[selectedNav.name];
 
       if (availableNav) {
-        Adapter.mergeSelectedRefinements(availableNav, selectedNav);
+        SearchAdapter.mergeSelectedRefinements(availableNav, selectedNav);
       } else {
-        const navigation = Adapter.extractNavigation(selectedNav);
+        const navigation = SearchAdapter.extractNavigation(selectedNav);
         navigation.selected = Object.keys(Array(navigation.refinements.length).fill(0))
           .map((value) => Number(value));
         navigations = { [selectedNav.name]: navigation, ...navigations };
@@ -172,7 +172,7 @@ namespace Adapter {
     name: template.name,
     rule: template.ruleName,
     zones: Object.keys(template.zones).reduce((zones, key) =>
-      Object.assign(zones, { [key]: Adapter.extractZone(template.zones[key]) }), {}),
+      Object.assign(zones, { [key]: SearchAdapter.extractZone(template.zones[key]) }), {}),
   });
 
   export const extractRecordCount = (recordCount: number) =>
@@ -182,15 +182,15 @@ namespace Adapter {
   export const extractPage = (state: Store.State, totalRecords: number, current?: number, pageSize?: number): Actions.Payload.Page => {
     const currentPageSize = pageSize || Selectors.pageSize(state);
     const currentPage = current || Selectors.page(state);
-    const last = Page.finalPage(currentPageSize, totalRecords);
-    const from = Page.fromResult(currentPage, currentPageSize);
-    const to = Page.toResult(currentPage, currentPageSize, totalRecords);
+    const last = PageAdapter.finalPage(currentPageSize, totalRecords);
+    const from = PageAdapter.fromResult(currentPage, currentPageSize);
+    const to = PageAdapter.toResult(currentPage, currentPageSize, totalRecords);
 
     return {
       from,
       last,
-      next: Page.nextPage(currentPage, last),
-      previous: Page.previousPage(currentPage),
+      next: PageAdapter.nextPage(currentPage, last),
+      previous: PageAdapter.previousPage(currentPage),
       to,
       current: currentPage,
     };
@@ -213,4 +213,4 @@ namespace Adapter {
   };
 }
 
-export default Adapter;
+export default SearchAdapter;

--- a/packages/@storefront/flux-capacitor/src/core/observer.ts
+++ b/packages/@storefront/flux-capacitor/src/core/observer.ts
@@ -3,7 +3,6 @@ import FluxCapacitor from '../flux-capacitor';
 import SearchAdapter from './adapters/search';
 import Events from './events';
 import Store from './store';
-import * as utils from './utils';
 
 type Observer = (oldState: any, newState: any, path: string) => void;
 

--- a/packages/@storefront/flux-capacitor/src/core/reducers/data/area.ts
+++ b/packages/@storefront/flux-capacitor/src/core/reducers/data/area.ts
@@ -1,5 +1,3 @@
-import Store from '../../store';
-
 export const DEFAULT_AREA = 'Production';
 
 export default function updateArea(state: string = DEFAULT_AREA): string {

--- a/packages/@storefront/flux-capacitor/src/core/reducers/data/details.ts
+++ b/packages/@storefront/flux-capacitor/src/core/reducers/data/details.ts
@@ -1,4 +1,3 @@
-import { Template } from 'groupby-api';
 import Actions from '../../actions';
 import SearchAdapter from '../../adapters/search';
 import Store from '../../store';

--- a/packages/@storefront/flux-capacitor/src/core/reducers/data/navigations.ts
+++ b/packages/@storefront/flux-capacitor/src/core/reducers/data/navigations.ts
@@ -1,5 +1,5 @@
 import Actions from '../../actions';
-import Adapter from '../../adapters/search';
+import SearchAdapter from '../../adapters/search';
 import Store from '../../store';
 
 export type Action = Actions.ResetRefinements
@@ -124,7 +124,7 @@ export const addRefinement = (state: State, { navigationId, value, low, high, ra
 
   if (navigationId in state.byId) {
     const index = state.byId[navigationId].refinements
-      .findIndex((ref) => Adapter.refinementsMatch(ref, refinement, range ? 'Range' : 'Value'));
+      .findIndex((ref) => SearchAdapter.refinementsMatch(ref, refinement, range ? 'Range' : 'Value'));
 
     return {
       ...state,

--- a/packages/@storefront/flux-capacitor/src/core/reducers/data/personalization.ts
+++ b/packages/@storefront/flux-capacitor/src/core/reducers/data/personalization.ts
@@ -2,7 +2,6 @@ import { createTransform, persistReducer } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
 import Actions from '../../actions';
 import Adapter from '../../adapters/personalization';
-import Selectors from '../../selectors';
 import Store from '../../store';
 
 export type Action = Actions.UpdateBiasing;

--- a/packages/@storefront/flux-capacitor/src/core/reducers/data/productsLoaded.ts
+++ b/packages/@storefront/flux-capacitor/src/core/reducers/data/productsLoaded.ts
@@ -1,5 +1,4 @@
 import Actions from '../../actions';
-import Store from '../../store';
 
 export type Action = Actions.ReceiveProductRecords;
 export type State = boolean;

--- a/packages/@storefront/flux-capacitor/src/core/reducers/data/recommendations.ts
+++ b/packages/@storefront/flux-capacitor/src/core/reducers/data/recommendations.ts
@@ -1,5 +1,4 @@
 import Actions from '../../actions';
-import RecommendationsAdapters from '../../adapters/recommendations';
 import Store from '../../store';
 
 export type Action = Actions.ReceiveRecommendationsProducts;

--- a/packages/@storefront/flux-capacitor/src/core/reducers/index.ts
+++ b/packages/@storefront/flux-capacitor/src/core/reducers/index.ts
@@ -1,7 +1,6 @@
 import * as redux from 'redux';
 import undoable, { includeAction } from 'redux-undo';
 import Actions from '../actions';
-import ConfigAdapter from '../adapters/configuration';
 import Store from '../store';
 import data from './data';
 import isFetching from './is-fetching';

--- a/packages/@storefront/flux-capacitor/src/core/reducers/is-running.ts
+++ b/packages/@storefront/flux-capacitor/src/core/reducers/is-running.ts
@@ -1,5 +1,4 @@
 import Actions from '../actions';
-import Store from '../store';
 
 export type Action = Actions.StartApp | Actions.ShutdownApp;
 export type State = boolean;

--- a/packages/@storefront/flux-capacitor/src/core/reducers/ui.ts
+++ b/packages/@storefront/flux-capacitor/src/core/reducers/ui.ts
@@ -38,4 +38,4 @@ export const removeComponentState = (state: State, { tagName, id }: Actions.Payl
     }
   });
 
-export const clearComponentState = (state: State): State => ({});
+export const clearComponentState = (_: State): State => ({});

--- a/packages/@storefront/flux-capacitor/src/core/reducers/ui.ts
+++ b/packages/@storefront/flux-capacitor/src/core/reducers/ui.ts
@@ -38,4 +38,4 @@ export const removeComponentState = (state: State, { tagName, id }: Actions.Payl
     }
   });
 
-export const clearComponentState = (_: State): State => ({});
+export const clearComponentState = (state: State): State => ({});

--- a/packages/@storefront/flux-capacitor/src/core/requests/index.ts
+++ b/packages/@storefront/flux-capacitor/src/core/requests/index.ts
@@ -2,7 +2,7 @@ import { Request } from 'groupby-api';
 import { QueryTimeAutocompleteConfig, QueryTimeProductSearchConfig } from 'sayt';
 import Payload from '../actions/payloads';
 import Configuration from '../adapters/configuration';
-import Recommendations from '../adapters/recommendations';
+import RecommendationsAdapter from '../adapters/recommendations';
 import ConfigurationType from '../configuration';
 import Selectors from '../selectors';
 import Store from '../store';
@@ -46,9 +46,9 @@ export const collectionRequest = new RequestBuilder<Request>(RequestHelpers.sear
 export const pastPurchaseProductsRequest = new RequestBuilder<Request>(RequestHelpers.pastPurchaseProducts, Configuration.pastPurchaseOverrides);
 export const productDetailsRequest = new RequestBuilder<Request>(RequestHelpers.search, Configuration.detailsOverrides);
 export const productsRequest = new RequestBuilder<Request>(RequestHelpers.products, Configuration.searchOverrides);
-export const recommendationsNavigationsRequest = new RequestBuilder<Recommendations.RecommendationsBody>(RequestHelpers.recommendationsNavigations, Configuration.recommendationsNavigationsOverrides);
-export const recommendationsProductIdsRequest = new RequestBuilder<Recommendations.RecommendationsRequest>(RequestHelpers.recommendationsProductIDs, Configuration.recommendationsIdsOverrides);
+export const recommendationsNavigationsRequest = new RequestBuilder<RecommendationsAdapter.RecommendationsBody>(RequestHelpers.recommendationsNavigations, Configuration.recommendationsNavigationsOverrides);
+export const recommendationsProductIdsRequest = new RequestBuilder<RecommendationsAdapter.RecommendationsRequest>(RequestHelpers.recommendationsProductIDs, Configuration.recommendationsIdsOverrides);
 export const recommendationsProductsRequest = new RequestBuilder<Request>(RequestHelpers.search, Configuration.recommendationsProductsOverrides);
-export const recommendationsSuggestionsRequest = new RequestBuilder<Recommendations.Request & { query: string }, Recommendations.Request>(RequestHelpers.recommendationsSuggestions, Configuration.recommendationsSuggestionsOverrides);
+export const recommendationsSuggestionsRequest = new RequestBuilder<RecommendationsAdapter.Request & { query: string }, RecommendationsAdapter.Request>(RequestHelpers.recommendationsSuggestions, Configuration.recommendationsSuggestionsOverrides);
 export const refinementsRequest = new RequestBuilder<Request>(RequestHelpers.search, Configuration.refinementsOverrides);
 /* tslint:enable */

--- a/packages/@storefront/flux-capacitor/src/core/requests/index.ts
+++ b/packages/@storefront/flux-capacitor/src/core/requests/index.ts
@@ -1,9 +1,7 @@
 import { Request } from 'groupby-api';
-import { QueryTimeAutocompleteConfig, QueryTimeProductSearchConfig } from 'sayt';
-import Payload from '../actions/payloads';
+import { QueryTimeAutocompleteConfig } from 'sayt';
 import Configuration from '../adapters/configuration';
 import RecommendationsAdapter from '../adapters/recommendations';
-import ConfigurationType from '../configuration';
 import Selectors from '../selectors';
 import Store from '../store';
 import { normalizeToFunction, GenericTransformer } from '../utils';

--- a/packages/@storefront/flux-capacitor/src/core/requests/utils.ts
+++ b/packages/@storefront/flux-capacitor/src/core/requests/utils.ts
@@ -4,8 +4,8 @@ import Payload from '../actions/payloads';
 import Autocomplete from '../adapters/autocomplete';
 import Configuration from '../adapters/configuration';
 import PastPurchaseAdapter from '../adapters/past-purchases';
-import Personalization from '../adapters/personalization';
-import Recommendations from '../adapters/recommendations';
+import PersonalizationAdapter from '../adapters/personalization';
+import RecommendationsAdapter from '../adapters/recommendations';
 import RequestAdapter from '../adapters/request';
 import SearchAdapter, { MAX_RECORDS } from '../adapters/search';
 import AppConfig from '../configuration';
@@ -14,9 +14,9 @@ import Store from '../store';
 import { normalizeToFunction } from '../utils';
 
 namespace RequestHelpers {
-  export type RequestBody = Recommendations.RecommendationsBody
-    | Recommendations.RecommendationsRequest
-    | Recommendations.PastPurchaseRequest;
+  export type RequestBody = RecommendationsAdapter.RecommendationsBody
+    | RecommendationsAdapter.RecommendationsRequest
+    | RecommendationsAdapter.PastPurchaseRequest;
 
   export const buildPostBody = (body: RequestBody) => ({
     method: 'POST',
@@ -70,11 +70,11 @@ namespace RequestHelpers {
   };
 
   // tslint:disable-next-line max-line-length
-  export const recommendationsSuggestions: BuildFunction<Partial<Recommendations.Request & { query: string }>, Recommendations.Request> = (state, overrideRequest = {}) => {
+  export const recommendationsSuggestions: BuildFunction<Partial<RecommendationsAdapter.Request & { query: string }>, RecommendationsAdapter.Request> = (state, overrideRequest = {}) => {
     const config = Selectors.config(state);
     const { query = false, ...restOfOverrideRequest } = overrideRequest;
 
-    const request = Recommendations.addLocationToRequest({
+    const request = RecommendationsAdapter.addLocationToRequest({
       size: config.autocomplete.recommendations.suggestionCount,
       matchPartial: {
         and: [{
@@ -89,7 +89,7 @@ namespace RequestHelpers {
   };
 
   // tslint:disable-next-line max-line-length
-  export const recommendationsNavigations: BuildFunction<Partial<Recommendations.RecommendationsBody>, Recommendations.RecommendationsBody> = (state, overrideRequest = {}) => {
+  export const recommendationsNavigations: BuildFunction<Partial<RecommendationsAdapter.RecommendationsBody>, RecommendationsAdapter.RecommendationsBody> = (state, overrideRequest = {}) => {
     const query = Selectors.query(state);
     const iNav = Selectors.config(state).recommendations.iNav;
     const sizeAndWindow = { size: iNav.size, window: iNav.window };
@@ -111,10 +111,10 @@ namespace RequestHelpers {
   };
 
   // tslint:disable-next-line max-line-length
-  export const recommendationsProductIDs: BuildFunction<Partial<Recommendations.RecommendationsRequest>, Recommendations.RecommendationsRequest> = (state, overrideRequest = {}) => {
+  export const recommendationsProductIDs: BuildFunction<Partial<RecommendationsAdapter.RecommendationsRequest>, RecommendationsAdapter.RecommendationsRequest> = (state, overrideRequest = {}) => {
     const config = Selectors.config(state);
 
-    const request = Recommendations.addLocationToRequest({
+    const request = RecommendationsAdapter.addLocationToRequest({
       size: config.recommendations.productSuggestions.productCount,
       type: 'viewProduct',
       target: config.recommendations.idField
@@ -161,7 +161,7 @@ namespace RequestHelpers {
 
   // tslint:disable-next-line max-line-length
   export const realTimeBiasing = (state: Store.State, request: Request): Request => {
-    const addedBiases = Personalization.convertBiasToSearch(state, request.refinements);
+    const addedBiases = PersonalizationAdapter.convertBiasToSearch(state, request.refinements);
 
     return {
       ...request,

--- a/packages/@storefront/flux-capacitor/src/core/requests/utils.ts
+++ b/packages/@storefront/flux-capacitor/src/core/requests/utils.ts
@@ -1,17 +1,13 @@
 import { Request } from 'groupby-api';
-import { QueryTimeAutocompleteConfig, QueryTimeProductSearchConfig } from 'sayt';
-import Payload from '../actions/payloads';
+import { QueryTimeAutocompleteConfig } from 'sayt';
 import Autocomplete from '../adapters/autocomplete';
 import Configuration from '../adapters/configuration';
 import PastPurchaseAdapter from '../adapters/past-purchases';
 import PersonalizationAdapter from '../adapters/personalization';
 import RecommendationsAdapter from '../adapters/recommendations';
 import RequestAdapter from '../adapters/request';
-import SearchAdapter, { MAX_RECORDS } from '../adapters/search';
-import AppConfig from '../configuration';
 import Selectors from '../selectors';
 import Store from '../store';
-import { normalizeToFunction } from '../utils';
 
 namespace RequestHelpers {
   export type RequestBody = RecommendationsAdapter.RecommendationsBody

--- a/packages/@storefront/flux-capacitor/src/core/sagas/autocomplete.ts
+++ b/packages/@storefront/flux-capacitor/src/core/sagas/autocomplete.ts
@@ -2,7 +2,7 @@ import { SelectedRefinement } from 'groupby-api';
 import * as effects from 'redux-saga/effects';
 import FluxCapacitor from '../../flux-capacitor';
 import Actions from '../actions';
-import Adapter from '../adapters/autocomplete';
+import AutocompleteAdapter from '../adapters/autocomplete';
 import ConfigAdapter from '../adapters/configuration';
 import Configuration from '../configuration';
 import {
@@ -50,11 +50,11 @@ export namespace Tasks {
 
       const responses = yield effects.all(requests);
       const navigationLabels = ConfigAdapter.extractAutocompleteNavigationLabels(config);
-      const autocompleteSuggestions = Adapter.extractSuggestions(responses[0], query, field, navigationLabels, config);
+      const autocompleteSuggestions = AutocompleteAdapter.extractSuggestions(responses[0], query, field, navigationLabels, config);
       const suggestions = recommendationsConfig.suggestionCount > 0 ?
         {
           ...autocompleteSuggestions,
-          suggestions: Adapter.mergeSuggestions(autocompleteSuggestions.suggestions, yield responses[1].json())
+          suggestions: AutocompleteAdapter.mergeSuggestions(autocompleteSuggestions.suggestions, yield responses[1].json())
         } : autocompleteSuggestions;
 
       yield effects.put(flux.actions.receiveAutocompleteSuggestions(suggestions));

--- a/packages/@storefront/flux-capacitor/src/core/sagas/autocomplete.ts
+++ b/packages/@storefront/flux-capacitor/src/core/sagas/autocomplete.ts
@@ -11,9 +11,9 @@ import {
   recommendationsSuggestionsRequest
 } from '../requests';
 import Selectors from '../selectors';
-import Requests from './requests';
+import RequestsTasks from './requests';
 
-export namespace Tasks {
+export namespace AutocompleteTasks {
   // tslint:disable-next-line max-line-length
   export function* fetchSuggestions(flux: FluxCapacitor, { payload: { query, request } }: Actions.FetchAutocompleteSuggestions) {
     try {
@@ -22,7 +22,7 @@ export namespace Tasks {
       const field = Selectors.autocompleteCategoryField(state);
       const requestBody = autocompleteSuggestionsRequest.composeRequest(state, request);
       const suggestionsRequest = effects.call(
-        Requests.autocomplete,
+        RequestsTasks.autocomplete,
         flux,
         query,
         requestBody
@@ -34,7 +34,7 @@ export namespace Tasks {
       if (recommendationsConfig.suggestionCount > 0) {
         const body = recommendationsSuggestionsRequest.composeRequest(state, { query });
         const trendingRequest = effects.call(
-          Requests.recommendations,
+          RequestsTasks.recommendations,
           {
             customerId: config.customerId,
             endpoint: 'searches',
@@ -50,10 +50,12 @@ export namespace Tasks {
 
       const responses = yield effects.all(requests);
       const navigationLabels = ConfigAdapter.extractAutocompleteNavigationLabels(config);
+      // tslint:disable-next-line max-line-length
       const autocompleteSuggestions = AutocompleteAdapter.extractSuggestions(responses[0], query, field, navigationLabels, config);
       const suggestions = recommendationsConfig.suggestionCount > 0 ?
         {
           ...autocompleteSuggestions,
+          // tslint:disable-next-line max-line-length
           suggestions: AutocompleteAdapter.mergeSuggestions(autocompleteSuggestions.suggestions, yield responses[1].json())
         } : autocompleteSuggestions;
 
@@ -73,7 +75,7 @@ export namespace Tasks {
         state,
         { refinements: requestRefinements, query, ...request }
       );
-      const res = yield effects.call(Requests.search, flux, requestBody);
+      const res = yield effects.call(RequestsTasks.search, flux, requestBody);
 
       yield effects.put(<any>flux.actions.receiveAutocompleteProducts(res));
     } catch (e) {
@@ -83,6 +85,6 @@ export namespace Tasks {
 }
 
 export default (flux: FluxCapacitor) => function* autocompleteSaga() {
-  yield effects.takeLatest(Actions.FETCH_AUTOCOMPLETE_SUGGESTIONS, Tasks.fetchSuggestions, flux);
-  yield effects.takeLatest(Actions.FETCH_AUTOCOMPLETE_PRODUCTS, Tasks.fetchProducts, flux);
+  yield effects.takeLatest(Actions.FETCH_AUTOCOMPLETE_SUGGESTIONS, AutocompleteTasks.fetchSuggestions, flux);
+  yield effects.takeLatest(Actions.FETCH_AUTOCOMPLETE_PRODUCTS, AutocompleteTasks.fetchProducts, flux);
 };

--- a/packages/@storefront/flux-capacitor/src/core/sagas/collection.ts
+++ b/packages/@storefront/flux-capacitor/src/core/sagas/collection.ts
@@ -2,14 +2,14 @@ import * as effects from 'redux-saga/effects';
 import FluxCapacitor from '../../flux-capacitor';
 import Actions from '../actions';
 import { collectionRequest } from '../requests';
-import Requests from './requests';
+import RequestsTasks from './requests';
 
-export namespace Tasks {
+export namespace CollectionTasks {
   export function* fetchCount(flux: FluxCapacitor, { payload: { collection, request } }: Actions.FetchCollectionCount) {
     try {
       const state = yield effects.select();
       const requestBody = collectionRequest.composeRequest(state, { collection, ...request });
-      const res = yield effects.call(Requests.search, flux, requestBody);
+      const res = yield effects.call(RequestsTasks.search, flux, requestBody);
 
       yield effects.put(flux.actions.receiveCollectionCount({
         collection,
@@ -22,5 +22,5 @@ export namespace Tasks {
 }
 
 export default (flux: FluxCapacitor) => function* saga() {
-  yield effects.takeEvery(Actions.FETCH_COLLECTION_COUNT, Tasks.fetchCount, flux);
+  yield effects.takeEvery(Actions.FETCH_COLLECTION_COUNT, CollectionTasks.fetchCount, flux);
 };

--- a/packages/@storefront/flux-capacitor/src/core/sagas/product-details.ts
+++ b/packages/@storefront/flux-capacitor/src/core/sagas/product-details.ts
@@ -3,11 +3,10 @@ import FluxCapacitor from '../../flux-capacitor';
 import Actions from '../actions';
 import Events from '../events';
 import { productDetailsRequest } from '../requests';
-import Store from '../store';
 import * as utils from '../utils';
-import Requests from './requests';
+import RequestsTasks from './requests';
 
-export namespace Tasks {
+export namespace ProductDetailsTasks {
   export function* fetchProductDetails(flux: FluxCapacitor, { payload: { id, request } }: Actions.FetchProductDetails) {
     try {
       const state = yield effects.select();
@@ -21,7 +20,7 @@ export namespace Tasks {
           ...request
         }
       );
-      const { records, template } = yield effects.call(Requests.search, flux, requestBody);
+      const { records, template } = yield effects.call(RequestsTasks.search, flux, requestBody);
 
       if (records.length) {
         let [record] = records;
@@ -42,5 +41,5 @@ export namespace Tasks {
 }
 
 export default (flux: FluxCapacitor) => function* saga() {
-  yield effects.takeLatest(Actions.FETCH_PRODUCT_DETAILS, Tasks.fetchProductDetails, flux);
+  yield effects.takeLatest(Actions.FETCH_PRODUCT_DETAILS, ProductDetailsTasks.fetchProductDetails, flux);
 };

--- a/packages/@storefront/flux-capacitor/src/core/sagas/products.ts
+++ b/packages/@storefront/flux-capacitor/src/core/sagas/products.ts
@@ -59,7 +59,7 @@ export namespace ProductsTasks {
     return yield effects.call(RequestsTasks.search, flux, request);
   }
 
-  export function* fetchNavigations(_: FluxCapacitor, __: Actions.FetchProducts) {
+  export function* fetchNavigations(flux: FluxCapacitor, action: Actions.FetchProducts) {
     try {
       const state = yield effects.select();
       const config = yield effects.select(Selectors.config);

--- a/packages/@storefront/flux-capacitor/src/core/sagas/products.ts
+++ b/packages/@storefront/flux-capacitor/src/core/sagas/products.ts
@@ -9,9 +9,9 @@ import { productsRequest, recommendationsNavigationsRequest } from '../requests'
 import Selectors from '../selectors';
 import Store from '../store';
 import * as utils from '../utils';
-import Requests from './requests';
+import RequestsTasks from './requests';
 
-export namespace Tasks {
+export namespace ProductsTasks {
   export function* fetchProducts(flux: FluxCapacitor, ignoreHistory: boolean = false, action: Actions.FetchProducts) {
     try {
       let [result, navigations]: [Results, Store.Recommendations.Navigation[]] = yield effects.all([
@@ -56,10 +56,10 @@ export namespace Tasks {
     const state = yield effects.select();
     const request = productsRequest.composeRequest(state, action.payload.request);
 
-    return yield effects.call(Requests.search, flux, request);
+    return yield effects.call(RequestsTasks.search, flux, request);
   }
 
-  export function* fetchNavigations(flux: FluxCapacitor, action: Actions.FetchProducts) {
+  export function* fetchNavigations(_: FluxCapacitor, __: Actions.FetchProducts) {
     try {
       const state = yield effects.select();
       const config = yield effects.select(Selectors.config);
@@ -67,7 +67,7 @@ export namespace Tasks {
       if (iNav.navigations.sort || iNav.refinements.sort) {
         const body = recommendationsNavigationsRequest.composeRequest(state);
         const recommendationsResponse = yield effects.call(
-          Requests.recommendations,
+          RequestsTasks.recommendations,
           {
             customerId: config.customerId,
             endpoint: 'refinements',
@@ -109,7 +109,7 @@ export namespace Tasks {
       }
 
       const requestBody = productsRequest.composeRequest(state, { pageSize, skip, ...action.payload.request });
-      const result = yield effects.call(Requests.search, flux, requestBody);
+      const result = yield effects.call(RequestsTasks.search, flux, requestBody);
 
       flux.emit(Events.BEACON_SEARCH, result.id);
 
@@ -135,9 +135,9 @@ export namespace Tasks {
 
 export default (flux: FluxCapacitor) => {
   return function* saga() {
-    yield effects.takeLatest(Actions.FETCH_PRODUCTS, Tasks.fetchProducts, flux, false);
-    yield effects.takeLatest(Actions.FETCH_PRODUCTS_WITHOUT_HISTORY, Tasks.fetchProducts, flux, true);
-    yield effects.takeLatest(Actions.FETCH_PRODUCTS_WHEN_HYDRATED, Tasks.fetchProductsWhenHydrated, flux);
-    yield effects.takeEvery(Actions.FETCH_MORE_PRODUCTS, Tasks.fetchMoreProducts, flux);
+    yield effects.takeLatest(Actions.FETCH_PRODUCTS, ProductsTasks.fetchProducts, flux, false);
+    yield effects.takeLatest(Actions.FETCH_PRODUCTS_WITHOUT_HISTORY, ProductsTasks.fetchProducts, flux, true);
+    yield effects.takeLatest(Actions.FETCH_PRODUCTS_WHEN_HYDRATED, ProductsTasks.fetchProductsWhenHydrated, flux);
+    yield effects.takeEvery(Actions.FETCH_MORE_PRODUCTS, ProductsTasks.fetchMoreProducts, flux);
   };
 };

--- a/packages/@storefront/flux-capacitor/src/core/sagas/recommendations.ts
+++ b/packages/@storefront/flux-capacitor/src/core/sagas/recommendations.ts
@@ -198,7 +198,7 @@ export namespace RecommendationsTasks {
   }
 
   // tslint:disable-next-line max-line-length
-  export function buildRequestFromSkus(_: FluxCapacitor, skus: Store.PastPurchases.PastPurchaseProduct[]): Partial<Request> {
+  export function buildRequestFromSkus(flux: FluxCapacitor, skus: Store.PastPurchases.PastPurchaseProduct[]): Partial<Request> {
     const ids: string[] = skus.map(({ sku }) => sku);
 
     return {

--- a/packages/@storefront/flux-capacitor/src/core/sagas/refinements.ts
+++ b/packages/@storefront/flux-capacitor/src/core/sagas/refinements.ts
@@ -8,16 +8,16 @@ import Events from '../events';
 import { refinementsRequest } from '../requests';
 import Selectors from '../selectors';
 import Store from '../store';
-import Requests from './requests';
+import RequestsTasks from './requests';
 
-export namespace Tasks {
+export namespace RefinementsTasks {
   // tslint:disable-next-line max-line-length
   export function* fetchMoreRefinements(flux: FluxCapacitor, { payload }: Actions.FetchMoreRefinements) {
     try {
       const state: Store.State = yield effects.select();
       const config = yield effects.select(Selectors.config);
       const requestBody = refinementsRequest.composeRequest(state, payload.request);
-      const res = yield effects.call(Requests.refinements, flux, requestBody, payload.navigationId);
+      const res = yield effects.call(RequestsTasks.refinements, flux, requestBody, payload.navigationId);
 
       flux.emit(Events.BEACON_MORE_REFINEMENTS, payload.navigationId);
       res.navigation = RecommendationsAdapter.sortAndPinNavigations(
@@ -34,5 +34,5 @@ export namespace Tasks {
 }
 
 export default (flux: FluxCapacitor) => function* saga() {
-  yield effects.takeLatest(Actions.FETCH_MORE_REFINEMENTS, Tasks.fetchMoreRefinements, flux);
+  yield effects.takeLatest(Actions.FETCH_MORE_REFINEMENTS, RefinementsTasks.fetchMoreRefinements, flux);
 };

--- a/packages/@storefront/flux-capacitor/src/core/sagas/refinements.ts
+++ b/packages/@storefront/flux-capacitor/src/core/sagas/refinements.ts
@@ -3,7 +3,7 @@ import FluxCapacitor from '../../flux-capacitor';
 import Actions from '../actions';
 import * as utils from '../actions/utils';
 import RecommendationsAdapter from '../adapters/recommendations';
-import Adapter from '../adapters/refinements';
+import RefinementsAdapter from '../adapters/refinements';
 import Events from '../events';
 import { refinementsRequest } from '../requests';
 import Selectors from '../selectors';
@@ -25,7 +25,7 @@ export namespace Tasks {
         Selectors.navigationSort(flux.store.getState()),
         config
       )[0];
-      const { navigationId, refinements, selected } = Adapter.mergeRefinements(res, state);
+      const { navigationId, refinements, selected } = RefinementsAdapter.mergeRefinements(res, state);
       yield effects.put(flux.actions.receiveMoreRefinements(navigationId, refinements, selected));
     } catch (e) {
       yield effects.put(utils.createAction(Actions.RECEIVE_MORE_REFINEMENTS, e));

--- a/packages/@storefront/flux-capacitor/src/core/sagas/requests.ts
+++ b/packages/@storefront/flux-capacitor/src/core/sagas/requests.ts
@@ -2,16 +2,12 @@ import { BridgeCallback, Request } from 'groupby-api';
 import * as effects from 'redux-saga/effects';
 import { QueryTimeAutocompleteConfig, SearchCallback } from 'sayt';
 import FluxCapacitor from '../../flux-capacitor';
-import Actions from '../actions';
 import PastPurchasesAdapter from '../adapters/past-purchases';
 import RecommendationsAdapter from '../adapters/recommendations';
-import Events from '../events';
 import RequestHelpers from '../requests/utils';
-import Selectors from '../selectors';
-import Store from '../store';
 import { fetch } from '../utils';
 
-namespace Requests {
+namespace RequestsTasks {
   export function* search(flux: FluxCapacitor, request: Request, cb?: BridgeCallback) {
     return yield effects.call([flux.clients.bridge, flux.clients.bridge.search], request, cb);
   }
@@ -46,4 +42,4 @@ namespace Requests {
   }
 }
 
-export default Requests;
+export default RequestsTasks;

--- a/packages/@storefront/flux-capacitor/src/core/selectors.ts
+++ b/packages/@storefront/flux-capacitor/src/core/selectors.ts
@@ -1,10 +1,7 @@
 import { SelectedRefinement } from 'groupby-api';
-import { QueryTimeAutocompleteConfig, QueryTimeProductSearchConfig } from 'sayt';
-import Autocomplete from './adapters/autocomplete';
 import Configuration from './adapters/configuration';
 import Request from './adapters/request';
 import Search, { MAX_RECORDS } from './adapters/search';
-import AppConfig from './configuration';
 import Store from './store';
 
 namespace Selectors {

--- a/packages/@storefront/flux-capacitor/src/core/store/index.ts
+++ b/packages/@storefront/flux-capacitor/src/core/store/index.ts
@@ -1,7 +1,6 @@
-import { applyMiddleware, compose, createStore, Store as ReduxStore } from 'redux';
+import { createStore, Store as ReduxStore } from 'redux';
 import { persistStore } from 'redux-persist';
 import createSagaMiddleware from 'redux-saga';
-import * as validatorMiddleware from 'redux-validator';
 import FluxCapacitor from '../../flux-capacitor';
 import Actions from '../actions';
 import ConfigurationAdapter from '../adapters/configuration';

--- a/packages/@storefront/flux-capacitor/src/core/store/index.ts
+++ b/packages/@storefront/flux-capacitor/src/core/store/index.ts
@@ -4,7 +4,7 @@ import createSagaMiddleware from 'redux-saga';
 import * as validatorMiddleware from 'redux-validator';
 import FluxCapacitor from '../../flux-capacitor';
 import Actions from '../actions';
-import Adapter from '../adapters/configuration';
+import ConfigurationAdapter from '../adapters/configuration';
 import Configuration from '../configuration';
 import reducer from '../reducers';
 import createSagas, { SAGA_CREATORS } from '../sagas';
@@ -21,13 +21,13 @@ namespace Store {
 
     const store = createStore<State>(
       reducer,
-      <State>Adapter.initialState(flux.__config),
+      <State>ConfigurationAdapter.initialState(flux.__config),
       middleware,
     );
 
     // cannot stub persistStore
     /* istanbul ignore next */
-    if (Adapter.isRealTimeBiasEnabled(flux.__config)) {
+    if (ConfigurationAdapter.isRealTimeBiasEnabled(flux.__config)) {
       persistStore(store);
     }
 

--- a/packages/@storefront/flux-capacitor/src/core/store/middleware.ts
+++ b/packages/@storefront/flux-capacitor/src/core/store/middleware.ts
@@ -1,5 +1,5 @@
 import * as cuid from 'cuid';
-import { applyMiddleware, compose, createStore, Middleware as ReduxMiddleware, Store } from 'redux';
+import { applyMiddleware, compose, Middleware as ReduxMiddleware, Store } from 'redux';
 import { batchActions, batchMiddleware, batchStoreEnhancer, POP, PUSH } from 'redux-batch-enhancer';
 import { ActionCreators as ReduxActionCreators } from 'redux-undo';
 import * as validatorMiddleware from 'redux-validator';
@@ -10,7 +10,6 @@ import ConfigurationAdapter from '../adapters/configuration';
 import PersonalizationAdapter from '../adapters/personalization';
 import Events from '../events';
 import Selectors from '../selectors';
-import * as utils from '../utils';
 
 export const RECALL_CHANGE_ACTIONS = [
   Actions.RESET_REFINEMENTS,

--- a/packages/@storefront/flux-capacitor/src/flux-capacitor.ts
+++ b/packages/@storefront/flux-capacitor/src/flux-capacitor.ts
@@ -4,7 +4,6 @@ import { Sayt } from 'sayt';
 import Actions from './core/actions';
 import ActionCreators from './core/actions/creators';
 import ConfigurationAdapter from './core/adapters/configuration';
-import SearchAdapter from './core/adapters/search';
 import Configuration from './core/configuration';
 import Emitter  from './core/emitter';
 import Events from './core/events';

--- a/packages/@storefront/flux-capacitor/src/flux-capacitor.ts
+++ b/packages/@storefront/flux-capacitor/src/flux-capacitor.ts
@@ -3,7 +3,7 @@ import { Action as ReduxAction, Store as ReduxStore } from 'redux';
 import { Sayt } from 'sayt';
 import Actions from './core/actions';
 import ActionCreators from './core/actions/creators';
-import Adapter from './core/adapters/configuration';
+import ConfigurationAdapter from './core/adapters/configuration';
 import SearchAdapter from './core/adapters/search';
 import Configuration from './core/configuration';
 import Emitter  from './core/emitter';
@@ -185,7 +185,7 @@ class FluxCapacitor extends Emitter {
     const networkConfig = config.network;
     return new Sayt(<any>{
       https: networkConfig.https,
-      collection: Adapter.extractAutocompleteCollection(config) || Adapter.extractCollection(config),
+      collection: ConfigurationAdapter.extractAutocompleteCollection(config) || ConfigurationAdapter.extractCollection(config),
       subdomain: config.customerId,
     });
   }

--- a/packages/@storefront/flux-capacitor/test/unit/core/sagas/autocomplete.ts
+++ b/packages/@storefront/flux-capacitor/test/unit/core/sagas/autocomplete.ts
@@ -2,14 +2,11 @@ import * as effects from 'redux-saga/effects';
 import Actions from '../../../../src/core/actions';
 import Adapter from '../../../../src/core/adapters/autocomplete';
 import ConfigAdapter from '../../../../src/core/adapters/configuration';
-import RecommendationsAdapter from '../../../../src/core/adapters/recommendations';
-import SearchAdapter from '../../../../src/core/adapters/search';
 import * as RequestBuilders from '../../../../src/core/requests';
 import RequestHelpers from '../../../../src/core/requests/utils';
-import sagaCreator, { Tasks } from '../../../../src/core/sagas/autocomplete';
+import sagaCreator, { AutocompleteTasks } from '../../../../src/core/sagas/autocomplete';
 import Requests from '../../../../src/core/sagas/requests';
 import Selectors from '../../../../src/core/selectors';
-import * as utils from '../../../../src/core/utils';
 import suite from '../../_suite';
 
 suite('autocomplete saga', ({ expect, spy, stub, sinon }) => {
@@ -21,8 +18,9 @@ suite('autocomplete saga', ({ expect, spy, stub, sinon }) => {
       const saga = sagaCreator(flux)();
 
       // tslint:disable-next-line max-line-length
-      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_AUTOCOMPLETE_SUGGESTIONS, Tasks.fetchSuggestions, flux));
-      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_AUTOCOMPLETE_PRODUCTS, Tasks.fetchProducts, flux));
+      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_AUTOCOMPLETE_SUGGESTIONS, AutocompleteTasks.fetchSuggestions, flux));
+      // tslint:disable-next-line max-line-length
+      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_AUTOCOMPLETE_PRODUCTS, AutocompleteTasks.fetchProducts, flux));
       saga.next();
     });
   });
@@ -61,7 +59,7 @@ suite('autocomplete saga', ({ expect, spy, stub, sinon }) => {
         stub(RequestBuilders.recommendationsSuggestionsRequest, 'composeRequest')
           .withArgs(state, { query }).returns(matchExact);
 
-        const task = Tasks.fetchSuggestions(flux, <any>{ payload: { query } });
+        const task = AutocompleteTasks.fetchSuggestions(flux, <any>{ payload: { query } });
 
         expect(task.next().value).to.eql(effects.select());
         expect(task.next(state).value).to.eql(effects.select(Selectors.config));
@@ -104,7 +102,7 @@ suite('autocomplete saga', ({ expect, spy, stub, sinon }) => {
         stub(Selectors, 'autocompleteCategoryField');
         stub(Adapter, 'extractSuggestions').returns(suggestions);
 
-        const task = Tasks.fetchSuggestions(flux, <any>{ payload: { query } });
+        const task = AutocompleteTasks.fetchSuggestions(flux, <any>{ payload: { query } });
 
         task.next();
         task.next(state);
@@ -132,7 +130,7 @@ suite('autocomplete saga', ({ expect, spy, stub, sinon }) => {
           .withArgs(state, { query }).returns(matchExact);
         stub(Selectors, 'autocompleteCategoryField');
 
-        const task = Tasks.fetchSuggestions(flux, <any>{ payload: { query } });
+        const task = AutocompleteTasks.fetchSuggestions(flux, <any>{ payload: { query } });
 
         task.next();
         task.next(state);
@@ -158,7 +156,7 @@ suite('autocomplete saga', ({ expect, spy, stub, sinon }) => {
         const recommendationsComposeRequest = stub(RequestBuilders.recommendationsSuggestionsRequest, 'composeRequest');
         stub(Selectors, 'autocompleteCategoryField');
 
-        const task = Tasks.fetchSuggestions(flux, <any>{ payload: { query, request: override } });
+        const task = AutocompleteTasks.fetchSuggestions(flux, <any>{ payload: { query, request: override } });
 
         task.next();
         task.next(state);
@@ -175,7 +173,7 @@ suite('autocomplete saga', ({ expect, spy, stub, sinon }) => {
           actions: { receiveAutocompleteSuggestions }
         };
 
-        const task = Tasks.fetchSuggestions(flux, <any>{ payload: { query: 'rain boots' } });
+        const task = AutocompleteTasks.fetchSuggestions(flux, <any>{ payload: { query: 'rain boots' } });
 
         task.next();
         expect(task.throw(error).value).to.eql(effects.put(receiveAutocompleteSuggestionsAction));
@@ -204,7 +202,7 @@ suite('autocomplete saga', ({ expect, spy, stub, sinon }) => {
           .withArgs(state, { refinements: [requestRefinements], query }).returns(request);
         stub(Selectors, 'config').returns(config);
 
-        const task = Tasks.fetchProducts(flux, action);
+        const task = AutocompleteTasks.fetchProducts(flux, action);
 
         expect(task.next().value).to.eql(effects.select());
         expect(task.next(state).value).to.eql(effects.call(searchRequest, flux, request));
@@ -222,7 +220,7 @@ suite('autocomplete saga', ({ expect, spy, stub, sinon }) => {
         const composeRequest = stub(RequestBuilders.autocompleteProductsRequest, 'composeRequest');
 
         // tslint:disable-next-line max-line-length
-        const task = Tasks.fetchProducts(null, <any>{ payload: { query, refinements, request: override } });
+        const task = AutocompleteTasks.fetchProducts(null, <any>{ payload: { query, refinements, request: override } });
 
         task.next();
         task.next(state);
@@ -238,7 +236,7 @@ suite('autocomplete saga', ({ expect, spy, stub, sinon }) => {
         };
         stub(RequestHelpers, 'autocompleteProducts');
 
-        const task = Tasks.fetchProducts(flux, <any>{ payload: {} });
+        const task = AutocompleteTasks.fetchProducts(flux, <any>{ payload: {} });
 
         task.next();
         expect(task.throw(error).value).to.eql(effects.put(receiveAutocompleteProductsAction));

--- a/packages/@storefront/flux-capacitor/test/unit/core/sagas/collection.ts
+++ b/packages/@storefront/flux-capacitor/test/unit/core/sagas/collection.ts
@@ -1,10 +1,8 @@
 import * as effects from 'redux-saga/effects';
 import Actions from '../../../../src/core/actions';
-import Adapters from '../../../../src/core/adapters';
 import { collectionRequest } from '../../../../src/core/requests';
-import sagaCreator, { Tasks } from '../../../../src/core/sagas/collection';
+import sagaCreator, { CollectionTasks } from '../../../../src/core/sagas/collection';
 import Requests from '../../../../src/core/sagas/requests';
-import Selectors from '../../../../src/core/selectors';
 import suite from '../../_suite';
 
 suite('collection saga', ({ expect, spy, stub }) => {
@@ -16,7 +14,7 @@ suite('collection saga', ({ expect, spy, stub }) => {
       const saga = sagaCreator(flux)();
 
       // tslint:disable-next-line max-line-length
-      expect(saga.next().value).to.eql(effects.takeEvery(Actions.FETCH_COLLECTION_COUNT, Tasks.fetchCount, flux));
+      expect(saga.next().value).to.eql(effects.takeEvery(Actions.FETCH_COLLECTION_COUNT, CollectionTasks.fetchCount, flux));
       saga.next();
     });
   });
@@ -35,7 +33,7 @@ suite('collection saga', ({ expect, spy, stub }) => {
         const state = { a: 'b' };
         stub(collectionRequest, 'composeRequest').withArgs(state, { collection }).returns(request);
 
-        const task = Tasks.fetchCount(flux, <any>{ payload: { collection } });
+        const task = CollectionTasks.fetchCount(flux, <any>{ payload: { collection } });
 
         expect(task.next().value).to.eql(effects.select());
         expect(task.next(state).value).to.eql(effects.call(searchRequest, flux, request));
@@ -50,7 +48,7 @@ suite('collection saga', ({ expect, spy, stub }) => {
         const override = { c: 'd' };
         const composeRequest = stub(collectionRequest, 'composeRequest');
 
-        const task = Tasks.fetchCount(null, <any>{ payload: { collection, request: override } });
+        const task = CollectionTasks.fetchCount(null, <any>{ payload: { collection, request: override } });
 
         task.next();
         task.next(state);
@@ -65,7 +63,7 @@ suite('collection saga', ({ expect, spy, stub }) => {
           actions: { receiveCollectionCount }
         };
 
-        const task = Tasks.fetchCount(flux, <any>{ payload: {} });
+        const task = CollectionTasks.fetchCount(flux, <any>{ payload: {} });
 
         task.next();
         expect(task.throw(error).value).to.eql(effects.put(receiveCollectionCountAction));

--- a/packages/@storefront/flux-capacitor/test/unit/core/sagas/product-details.ts
+++ b/packages/@storefront/flux-capacitor/test/unit/core/sagas/product-details.ts
@@ -3,9 +3,8 @@ import * as sinon from 'sinon';
 import Actions from '../../../../src/core/actions';
 import Events from '../../../../src/core/events';
 import { productDetailsRequest } from '../../../../src/core/requests';
-import sagaCreator, { Tasks } from '../../../../src/core/sagas/product-details';
+import sagaCreator, { ProductDetailsTasks } from '../../../../src/core/sagas/product-details';
 import Requests from '../../../../src/core/sagas/requests';
-import Selectors from '../../../../src/core/selectors';
 import * as utils from '../../../../src/core/utils';
 import suite from '../../_suite';
 
@@ -18,7 +17,7 @@ suite('product details saga', ({ expect, spy, stub }) => {
       const saga = sagaCreator(flux)();
 
       // tslint:disable-next-line max-line-length
-      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_PRODUCT_DETAILS, Tasks.fetchProductDetails, flux));
+      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_PRODUCT_DETAILS, ProductDetailsTasks.fetchProductDetails, flux));
       saga.next();
     });
   });
@@ -45,7 +44,7 @@ suite('product details saga', ({ expect, spy, stub }) => {
           refinements: [{ navigationName: 'id', type: 'Value', value: id }]
         }).returns(request);
 
-        const task = Tasks.fetchProductDetails(flux, <any>{ payload: { id } });
+        const task = ProductDetailsTasks.fetchProductDetails(flux, <any>{ payload: { id } });
 
         expect(task.next().value).to.eql(effects.select());
         expect(task.next(state).value).to.eql(effects.call(searchRequest, flux, request));
@@ -67,7 +66,7 @@ suite('product details saga', ({ expect, spy, stub }) => {
         };
         stub(productDetailsRequest, 'composeRequest').returns({ records: [] });
 
-        const task = Tasks.fetchProductDetails(flux, <any>{ payload: {} });
+        const task = ProductDetailsTasks.fetchProductDetails(flux, <any>{ payload: {} });
 
         task.next();
         task.next();
@@ -82,7 +81,7 @@ suite('product details saga', ({ expect, spy, stub }) => {
         const override = { c: 'd' };
         const composeRequest = stub(productDetailsRequest, 'composeRequest');
 
-        const task = Tasks.fetchProductDetails(null, <any>{ payload: { id, request: override } });
+        const task = ProductDetailsTasks.fetchProductDetails(null, <any>{ payload: { id, request: override } });
 
         task.next();
         task.next(state);
@@ -103,7 +102,7 @@ suite('product details saga', ({ expect, spy, stub }) => {
           actions: { receiveDetails }
         };
 
-        const task = Tasks.fetchProductDetails(flux, <any>{ payload: {} });
+        const task = ProductDetailsTasks.fetchProductDetails(flux, <any>{ payload: {} });
 
         task.next();
         expect(task.throw(error).value).to.eql(effects.put(receiveDetailsAction));

--- a/packages/@storefront/flux-capacitor/test/unit/core/sagas/products.ts
+++ b/packages/@storefront/flux-capacitor/test/unit/core/sagas/products.ts
@@ -1,13 +1,10 @@
 import * as effects from 'redux-saga/effects';
-import { ActionCreators } from 'redux-undo';
 import Actions from '../../../../src/core/actions';
-import PersonalizationAdapter from '../../../../src/core/adapters/personalization';
 import RecommendationsAdapter from '../../../../src/core/adapters/recommendations';
 import SearchAdapter from '../../../../src/core/adapters/search';
 import Events from '../../../../src/core/events';
 import { productsRequest, recommendationsNavigationsRequest } from '../../../../src/core/requests';
-import { Tasks as productDetailsTasks } from '../../../../src/core/sagas/product-details';
-import sagaCreator, { Tasks } from '../../../../src/core/sagas/products';
+import sagaCreator, { ProductsTasks } from '../../../../src/core/sagas/products';
 import Requests from '../../../../src/core/sagas/requests';
 import Selectors from '../../../../src/core/selectors';
 import * as utils from '../../../../src/core/utils';
@@ -32,12 +29,12 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
 
       const saga = sagaCreator(flux)();
 
-      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_PRODUCTS, Tasks.fetchProducts, flux, false));
+      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_PRODUCTS, ProductsTasks.fetchProducts, flux, false));
       // tslint:disable-next-line max-line-length
-      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_PRODUCTS_WITHOUT_HISTORY, Tasks.fetchProducts, flux, true));
+      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_PRODUCTS_WITHOUT_HISTORY, ProductsTasks.fetchProducts, flux, true));
       // tslint:disable-next-line max-line-length
-      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_PRODUCTS_WHEN_HYDRATED, Tasks.fetchProductsWhenHydrated, flux));
-      expect(saga.next().value).to.eql(effects.takeEvery(Actions.FETCH_MORE_PRODUCTS, Tasks.fetchMoreProducts, flux));
+      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_PRODUCTS_WHEN_HYDRATED, ProductsTasks.fetchProductsWhenHydrated, flux));
+      expect(saga.next().value).to.eql(effects.takeEvery(Actions.FETCH_MORE_PRODUCTS, ProductsTasks.fetchMoreProducts, flux));
       saga.next();
     });
   });
@@ -62,7 +59,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
             receiveProducts
           }
         };
-        const task = Tasks.fetchProducts(flux, false, <any>{});
+        const task = ProductsTasks.fetchProducts(flux, false, <any>{});
         const error = new Error();
         task.next();
         expect(task.throw(error).value).to.eql(effects.put(receiveProductsAction));
@@ -93,11 +90,11 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
         stub(RecommendationsAdapter, 'sortAndPinNavigations')
           .withArgs(response.availableNavigation, [], config).returns(availableNavigation);
 
-        const task = Tasks.fetchProducts(flux, false, action);
+        const task = ProductsTasks.fetchProducts(flux, false, action);
 
         expect(task.next().value).to.eql(effects.all(([
-          effects.call(Tasks.fetchProductsRequest, flux, action),
-          effects.call(Tasks.fetchNavigations, flux, action)
+          effects.call(ProductsTasks.fetchProductsRequest, flux, action),
+          effects.call(ProductsTasks.fetchNavigations, flux, action)
         ])));
         expect(task.next([response, undefined]).value).to.eql(effects.select(Selectors.config));
         expect(task.next(config).value).to.eql(effects.put(<any>[receiveProductsAction]));
@@ -123,7 +120,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
           saveState: () => undefined
         };
 
-        const task = Tasks.fetchProducts(<any>flux, false, <any>{ hello: 'hello' });
+        const task = ProductsTasks.fetchProducts(<any>flux, false, <any>{ hello: 'hello' });
         task.next();
         task.next([{ redirect: true }, undefined]);
         task.next();
@@ -150,7 +147,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
           saveState: () => undefined,
         };
 
-        const task = Tasks.fetchProducts(<any>flux, false, <any>{});
+        const task = ProductsTasks.fetchProducts(<any>flux, false, <any>{});
         task.next();
         task.next([{ redirect: false, totalRecordCount: 1, records: [record] }, undefined]);
         expect(task.next(config).value).to.eql(effects.put(fetchProductDetailsAction));
@@ -174,7 +171,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
           saveState: () => undefined
         };
 
-        const task = Tasks.fetchProducts(<any>flux, false, <any>{});
+        const task = ProductsTasks.fetchProducts(<any>flux, false, <any>{});
         task.next();
         task.next(config);
         expect(task.next([products, new Error()]).value).to.eql(effects.put(receiveProductsAction));
@@ -228,7 +225,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
           { name: 'other', refinements: singleRefinement },
         ];
 
-        const task = Tasks.fetchProducts(<any>flux, false, <any>{});
+        const task = ProductsTasks.fetchProducts(<any>flux, false, <any>{});
         task.next();
         task.next([{ availableNavigation }, sortArray]);
         expect(task.next(config).value)
@@ -295,7 +292,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
           { name: 'other', refinements: singleRefinement },
         ];
 
-        const task = Tasks.fetchProducts(<any>flux, false, <any>{});
+        const task = ProductsTasks.fetchProducts(<any>flux, false, <any>{});
         task.next();
         task.next([{ availableNavigation: avail }, sortArray]);
         expect(task.next(config).value)
@@ -362,7 +359,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
           { name: 'other', refinements: singleRefinement },
         ];
 
-        const task = Tasks.fetchProducts(<any>flux, false, <any>{});
+        const task = ProductsTasks.fetchProducts(<any>flux, false, <any>{});
         task.next();
         task.next([{ availableNavigation: avail }, sortArray]);
         expect(task.next(config).value).
@@ -410,7 +407,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
           { name: 'test1', values: singleRefinement },
         ];
 
-        const task = Tasks.fetchProducts(<any>flux, false, <any>{});
+        const task = ProductsTasks.fetchProducts(<any>flux, false, <any>{});
         task.next();
         task.next([{ availableNavigation }, sortArray]);
         expect(task.next(config).value)
@@ -429,7 +426,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
         const flux: any = { store: { getState, dispatch } };
         stub(Selectors, 'realTimeBiasesHydrated').returns(true);
 
-        const task = Tasks.fetchProductsWhenHydrated(flux, <any>{ payload });
+        const task = ProductsTasks.fetchProductsWhenHydrated(flux, <any>{ payload });
         expect(task.next().value).to.eql(effects.put(payload));
         task.next();
 
@@ -443,7 +440,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
         const flux: any = { store: { getState, dispatch }, once };
         stub(Selectors, 'realTimeBiasesHydrated').returns(false);
 
-        const task = Tasks.fetchProductsWhenHydrated(flux, <any>{ payload });
+        const task = ProductsTasks.fetchProductsWhenHydrated(flux, <any>{ payload });
         task.next();
 
         expect(dispatch).to.not.be.called;
@@ -468,7 +465,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
         const searchRequestCall = stub(Requests, 'search').returns(response);
         stub(productsRequest, 'composeRequest').withArgs(state).returns(request);
 
-        const task = Tasks.fetchProductsRequest(flux, action);
+        const task = ProductsTasks.fetchProductsRequest(flux, action);
 
         expect(task.next().value).to.eql(effects.select());
         expect(task.next(state).value).to.eql(effects.call(searchRequestCall, flux, request));
@@ -480,7 +477,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
         const override = { c: 'd' };
         const composeRequest = stub(productsRequest, 'composeRequest');
 
-        const task = Tasks.fetchProductsRequest(null, <any>{ payload: { request: override } });
+        const task = ProductsTasks.fetchProductsRequest(null, <any>{ payload: { request: override } });
 
         task.next();
         task.next(state);
@@ -491,7 +488,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
         const error = new Error();
         const flux: any = {};
 
-        const task = Tasks.fetchProductsRequest(flux, <any>{});
+        const task = ProductsTasks.fetchProductsRequest(flux, <any>{});
 
         expect(task.throw(error)).to.throw;
       });
@@ -524,7 +521,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
         stub(Selectors, 'productsWithMetadata').returns([{ index: 1 }, { index: 2 }, { index: 3 }]);
         stub(Selectors, 'recordCount').returns(50);
 
-        const task = Tasks.fetchMoreProducts(flux, action);
+        const task = ProductsTasks.fetchMoreProducts(flux, action);
 
         expect(task.next().value).to.eql(effects.select());
         expect(task.next(state).value).to.eql(effects.put(infiniteScrollRequestStateAction));
@@ -564,7 +561,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
         stub(Selectors, 'productsWithMetadata').returns([]);
         stub(Selectors, 'recordCount').returns(50);
 
-        const task = Tasks.fetchMoreProducts(flux, action);
+        const task = ProductsTasks.fetchMoreProducts(flux, action);
 
         expect(task.next().value).to.eql(effects.select());
         expect(task.next(state).value).to.eql(effects.put(infiniteScrollRequestStateAction));
@@ -605,7 +602,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
         stub(Selectors, 'productsWithMetadata').returns([{ index: 15 }, { index: 16 }, { index: 17 }]);
         stub(Selectors, 'recordCount').returns(50);
 
-        const task = Tasks.fetchMoreProducts(flux, action);
+        const task = ProductsTasks.fetchMoreProducts(flux, action);
 
         expect(task.next().value).to.eql(effects.select());
         expect(task.next(state).value).to.eql(effects.put(infiniteScrollRequestStateAction));
@@ -632,7 +629,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
         };
         stub(Selectors, 'recordCount').returns(products.length);
 
-        const task = Tasks.fetchMoreProducts(flux, action);
+        const task = ProductsTasks.fetchMoreProducts(flux, action);
 
         expect(task.next().value).to.eql(effects.select());
         task.next(state);
@@ -656,7 +653,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
         stub(Selectors, 'productsWithMetadata').returns(products);
         stub(Selectors, 'recordCount').returns(50);
 
-        const task = Tasks.fetchMoreProducts(flux, action);
+        const task = ProductsTasks.fetchMoreProducts(flux, action);
 
         expect(task.next().value).to.eql(effects.select());
         task.next(state);
@@ -679,7 +676,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
         stub(Selectors, 'productsWithMetadata').returns([]);
         stub(Selectors, 'recordCount').returns(50);
 
-        const task = Tasks.fetchMoreProducts(flux, action);
+        const task = ProductsTasks.fetchMoreProducts(flux, action);
 
         expect(task.next().value).to.eql(effects.select());
         task.next(state);
@@ -704,7 +701,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
         stub(Selectors, 'recordCount');
         stub(SearchAdapter, 'extractRecordCount');
 
-        const task = Tasks.fetchMoreProducts(flux, <any>{
+        const task = ProductsTasks.fetchMoreProducts(flux, <any>{
           payload: { forward: true, amount: pageSize, request: override }
         });
 
@@ -723,7 +720,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
           actions: { receiveMoreProducts }
         };
 
-        const task = Tasks.fetchMoreProducts(flux, <any>{});
+        const task = ProductsTasks.fetchMoreProducts(flux, <any>{});
 
         task.next();
         expect(task.throw(error).value).to.eql(effects.put(receiveMoreProductsAction));
@@ -770,7 +767,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
         const recommendationsRequest = stub(Requests, 'recommendations').returns(recommendations);
         stub(recommendationsNavigationsRequest, 'composeRequest').withArgs(state).returns(body);
 
-        const task = Tasks.fetchNavigations(<any>{}, <any>{ payload: {} });
+        const task = ProductsTasks.fetchNavigations(<any>{}, <any>{ payload: {} });
 
         expect(task.next().value).to.eql(effects.select());
         expect(task.next(state).value).to.eql(effects.select(Selectors.config));
@@ -823,7 +820,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
         const recommendationsRequest = stub(Requests, 'recommendations').returns(recommendations);
         stub(recommendationsNavigationsRequest, 'composeRequest').withArgs(state).returns(body);
 
-        const task = Tasks.fetchNavigations(<any>{}, <any>{ payload: {} });
+        const task = ProductsTasks.fetchNavigations(<any>{}, <any>{ payload: {} });
 
         task.next();
         task.next(state);
@@ -859,7 +856,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
         const returnVal: any = [{ values: 'truthy' }, { values: 'literally truthy' }];
         const jsonResult = 'hello';
 
-        const task = Tasks.fetchNavigations(<any>{}, <any>{ payload: {} });
+        const task = ProductsTasks.fetchNavigations(<any>{}, <any>{ payload: {} });
 
         task.next();
         task.next();
@@ -891,7 +888,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
           }
         };
 
-        const task = Tasks.fetchNavigations(flux, <any>{ payload: {} });
+        const task = ProductsTasks.fetchNavigations(flux, <any>{ payload: {} });
 
         task.next();
         expect(receiveRecommendationsRefinements).to.not.be.called;
@@ -925,7 +922,7 @@ suite('products saga', ({ sinon, expect, spy, stub }) => {
           }
         };
 
-        const task = Tasks.fetchNavigations(flux, <any>{ payload: {} });
+        const task = ProductsTasks.fetchNavigations(flux, <any>{ payload: {} });
         task.next();
         expect(task.throw(error).value).to.eq(error);
       });

--- a/packages/@storefront/flux-capacitor/test/unit/core/sagas/recommendations.ts
+++ b/packages/@storefront/flux-capacitor/test/unit/core/sagas/recommendations.ts
@@ -2,12 +2,9 @@ import * as effects from 'redux-saga/effects';
 import Actions from '../../../../src/core/actions';
 import ConfigAdapter from '../../../../src/core/adapters/configuration';
 import PageAdapter from '../../../../src/core/adapters/page';
-import PastPurchaseAdapter from '../../../../src/core/adapters/past-purchases';
-import RecommendationsAdapter from '../../../../src/core/adapters/recommendations';
 import SearchAdapter from '../../../../src/core/adapters/search';
-import { receivePage } from '../../../../src/core/reducers/data/page';
 import * as RequestBuilders from '../../../../src/core/requests';
-import sagaCreator, { MissingPayloadError, Tasks } from '../../../../src/core/sagas/recommendations';
+import sagaCreator, { MissingPayloadError, RecommendationsTasks } from '../../../../src/core/sagas/recommendations';
 import Requests from '../../../../src/core/sagas/requests';
 import Selectors from '../../../../src/core/selectors';
 import * as utils from '../../../../src/core/utils';
@@ -22,11 +19,11 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
       const saga = sagaCreator(flux)();
 
       // tslint:disable max-line-length
-      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_RECOMMENDATIONS_PRODUCTS, Tasks.fetchRecommendationsProducts, flux));
-      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_PAST_PURCHASES, Tasks.fetchPastPurchases, flux));
-      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_PAST_PURCHASE_PRODUCTS, Tasks.fetchPastPurchaseProducts, flux));
-      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_SAYT_PAST_PURCHASES, Tasks.fetchSaytPastPurchases, flux));
-      expect(saga.next().value).to.eql(effects.takeEvery(Actions.FETCH_MORE_PAST_PURCHASE_PRODUCTS, Tasks.fetchMorePastPurchaseProducts, flux));
+      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_RECOMMENDATIONS_PRODUCTS, RecommendationsTasks.fetchRecommendationsProducts, flux));
+      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_PAST_PURCHASES, RecommendationsTasks.fetchPastPurchases, flux));
+      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_PAST_PURCHASE_PRODUCTS, RecommendationsTasks.fetchPastPurchaseProducts, flux));
+      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_SAYT_PAST_PURCHASES, RecommendationsTasks.fetchSaytPastPurchases, flux));
+      expect(saga.next().value).to.eql(effects.takeEvery(Actions.FETCH_MORE_PAST_PURCHASE_PRODUCTS, RecommendationsTasks.fetchMorePastPurchaseProducts, flux));
       saga.next();
       // tslint:enable max-line-length
     });
@@ -63,7 +60,7 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
           ]
         }).returns(requestBody);
 
-        const task = Tasks.fetchRecommendationsProducts(flux, <any>{ payload: {} });
+        const task = RecommendationsTasks.fetchRecommendationsProducts(flux, <any>{ payload: {} });
 
         expect(task.next().value).to.eql(effects.select());
         expect(task.next(state).value).to.eql(effects.select(Selectors.config));
@@ -87,7 +84,7 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         const productSuggestions = { productCount };
         const config = { customerId, recommendations: { productSuggestions } };
 
-        const task = Tasks.fetchRecommendationsProducts(<any>{}, <any>{ payload: {} });
+        const task = RecommendationsTasks.fetchRecommendationsProducts(<any>{}, <any>{ payload: {} });
 
         task.next();
         task.next(config);
@@ -100,7 +97,7 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         const config = { recommendations: { productSuggestions: { productCount: 1 } } };
         const composeRequest = stub(RequestBuilders.recommendationsProductIdsRequest, 'composeRequest');
 
-        const task = Tasks.fetchRecommendationsProducts(null, <any>{ payload: { request: override } });
+        const task = RecommendationsTasks.fetchRecommendationsProducts(null, <any>{ payload: { request: override } });
 
         task.next();
         task.next(state);
@@ -114,7 +111,7 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         const receiveRecommendationsProducts = spy(() => receiveRecommendationsProductsAction);
         const flux: any = { actions: { receiveRecommendationsProducts } };
 
-        const task = Tasks.fetchRecommendationsProducts(flux, <any>{ payload: {} });
+        const task = RecommendationsTasks.fetchRecommendationsProducts(flux, <any>{ payload: {} });
 
         task.next();
         expect(task.throw(error).value).to.eql(effects.put(receiveRecommendationsProductsAction));
@@ -134,7 +131,7 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         const secure = stub(ConfigAdapter, 'extractSecuredPayload').returns(securedPayload);
         const ppRequest = stub(Requests, 'pastPurchases').returns({ json: () => jsonResult });
 
-        const task = Tasks.fetchPastPurchaseSkus({ customerId }, endpoint, query);
+        const task = RecommendationsTasks.fetchPastPurchaseSkus({ customerId }, endpoint, query);
 
         // tslint:disable-next-line max-line-length
         expect(task.next().value).to.eql(effects.call(ppRequest, {
@@ -151,7 +148,7 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         const customerId = 'id';
         stub(ConfigAdapter, 'extractSecuredPayload').returns(securedPayload);
 
-        const task = Tasks.fetchPastPurchaseSkus({ customerId }, 'endpoint');
+        const task = RecommendationsTasks.fetchPastPurchaseSkus({ customerId }, 'endpoint');
 
         try {
           task.next();
@@ -166,7 +163,7 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         const securedPayload = 'secured';
         stub(ConfigAdapter, 'extractSecuredPayload').returns(securedPayload);
 
-        const task = Tasks.fetchPastPurchaseSkus({ customerId: 'id' }, 'endpoint', 'query');
+        const task = RecommendationsTasks.fetchPastPurchaseSkus({ customerId: 'id' }, 'endpoint', 'query');
 
         try {
           task.next();
@@ -194,7 +191,7 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
           sort: [{ type: 'ByIds', ids }],
         };
 
-        const req = Tasks.buildRequestFromSkus(flux, skus);
+        const req = RecommendationsTasks.buildRequestFromSkus(flux, skus);
 
         expect(req).to.eql(newRequest);
       });
@@ -210,7 +207,7 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         // tslint:disable-next-line max-line-length
         const extractPastPurchaseProductCount = stub(ConfigAdapter, 'extractPastPurchaseProductCount').returns(productCount);
 
-        const task = Tasks.fetchPastPurchases(flux, <any>{});
+        const task = RecommendationsTasks.fetchPastPurchases(flux, <any>{});
 
         expect(task.next().value).to.eql(effects.select(Selectors.config));
         expect(task.next(config).value).to.eql(effects.put(receivePastPurchaseSkus([])));
@@ -230,10 +227,10 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         // tslint:disable-next-line max-line-length
         const extractPastPurchaseProductCount = stub(ConfigAdapter, 'extractPastPurchaseProductCount').returns(productCount);
 
-        const task = Tasks.fetchPastPurchases(flux, <any>{});
+        const task = RecommendationsTasks.fetchPastPurchases(flux, <any>{});
 
         expect(task.next().value).to.eql(effects.select(Selectors.config));
-        expect(task.next(config).value).to.eql(effects.call(<any>Tasks.fetchPastPurchaseSkus, config, 'popular'));
+        expect(task.next(config).value).to.eql(effects.call(<any>RecommendationsTasks.fetchPastPurchaseSkus, config, 'popular'));
         expect(task.next(resultArray).value).to.eql(effects.put(<any>[allRecordCount, data]));
         expect(task.next().done).to.be.true;
         expect(receivePastPurchaseSkus).to.be.calledWith(resultArray);
@@ -245,7 +242,7 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         const receivePastPurchaseSkus = spy(() => error);
         const flux: any = { actions: { receivePastPurchaseSkus } };
 
-        const task = Tasks.fetchPastPurchases(flux, <any>{});
+        const task = RecommendationsTasks.fetchPastPurchases(flux, <any>{});
 
         task.next();
         expect(task.throw(error).value).to.eql(effects.put(receivePastPurchaseSkus(error)));
@@ -257,7 +254,7 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         const receivePastPurchaseSkus = spy(() => error);
         const flux: any = { actions: { receivePastPurchaseSkus } };
 
-        const task = Tasks.fetchPastPurchases(flux, <any>{});
+        const task = RecommendationsTasks.fetchPastPurchases(flux, <any>{});
 
         task.next();
         expect(task.throw(error).value).to.eql(undefined);
@@ -270,7 +267,7 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         const action: any = {};
         const config = {};
 
-        const task = Tasks.fetchPastPurchaseProducts(flux, action);
+        const task = RecommendationsTasks.fetchPastPurchaseProducts(flux, action);
 
         expect(task.next().value).to.eql(effects.select(Selectors.pastPurchases));
         expect(task.next([]).done).to.be.true;
@@ -281,10 +278,10 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         const override = { c: 'd' };
         const pastPurchaseFromSkus = { e: 'f' };
         const composeRequest = stub(RequestBuilders.pastPurchaseProductsRequest, 'composeRequest');
-        stub(Tasks, 'buildRequestFromSkus').returns(pastPurchaseFromSkus);
+        stub(RecommendationsTasks, 'buildRequestFromSkus').returns(pastPurchaseFromSkus);
         stub(Selectors, 'pastPurchaseQuery').returns;
 
-        const task = Tasks.fetchPastPurchaseProducts(null, <any>{ payload: { request: override } });
+        const task = RecommendationsTasks.fetchPastPurchaseProducts(null, <any>{ payload: { request: override } });
 
         task.next();
         task.next(['a']);
@@ -301,7 +298,7 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         const flux: any = { actions: { receivePastPurchaseProducts } };
         const action: any = {};
 
-        const task = Tasks.fetchPastPurchaseProducts(flux, action);
+        const task = RecommendationsTasks.fetchPastPurchaseProducts(flux, action);
 
         task.next();
         expect(task.throw(error).value).to.eql(effects.put(receivePastPurchaseProducts(error)));
@@ -341,7 +338,7 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         const augmentProducts = stub(SearchAdapter, 'augmentProducts').returns(productData);
         const extractRecordCount = stub(SearchAdapter, 'extractRecordCount').returns(productData);
         const searchRequest = stub(Requests, 'search').returns(result);
-        stub(Tasks, 'buildRequestFromSkus').withArgs(flux, pastPurchaseSkus).returns(pastPurchasesFromSkus);
+        stub(RecommendationsTasks, 'buildRequestFromSkus').withArgs(flux, pastPurchaseSkus).returns(pastPurchasesFromSkus);
         stub(RequestBuilders.pastPurchaseProductsRequest, 'composeRequest')
           .withArgs(state, {
             ...pastPurchasesFromSkus,
@@ -350,7 +347,7 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         stub(PageAdapter, 'currentPage').withArgs(request.skip, request.pageSize).returns(currentPage);
         stub(SearchAdapter, 'combineNavigations').withArgs(productData).returns(navigations);
 
-        const task = Tasks.fetchPastPurchaseProducts(flux, <any>{ payload: {} });
+        const task = RecommendationsTasks.fetchPastPurchaseProducts(flux, <any>{ payload: {} });
 
         expect(task.next().value).to.eql(effects.select(Selectors.pastPurchases));
         expect(task.next(pastPurchaseSkus).value).to.eql(effects.select());
@@ -398,14 +395,14 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         const pastPurchaseSkusSelector = stub(Selectors, 'pastPurchases').returns(pastPurchaseSkus);
         const searchRequest = stub(Requests, 'search').returns(results);
         stub(Selectors, 'pastPurchaseProductsWithMetadata').returns([{ index: 1 }, { index: 2 }, { index: 3 }]);
-        stub(Tasks, 'buildRequestFromSkus').withArgs(flux, pastPurchaseSkus).returns(pastPurchasesFromSkus);
+        stub(RecommendationsTasks, 'buildRequestFromSkus').withArgs(flux, pastPurchaseSkus).returns(pastPurchasesFromSkus);
         stub(RequestBuilders.pastPurchaseProductsRequest, 'composeRequest').withArgs(state, {
           pageSize,
           skip: 3,
           ...pastPurchasesFromSkus,
         }).returns(request);
 
-        const task = Tasks.fetchMorePastPurchaseProducts(flux, action);
+        const task = RecommendationsTasks.fetchMorePastPurchaseProducts(flux, action);
 
         expect(task.next().value).to.eql(effects.select());
         expect(task.next(state).value).to.eql(effects.select(pastPurchaseSkusSelector));
@@ -450,14 +447,14 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         const searchRequest = stub(Requests, 'search').returns(results);
         stub(Selectors, 'pastPurchaseProductsWithMetadata').returns([{ index: 11 }, { index: 12 }, { index: 13 }]);
         stub(Selectors, 'pastPurchasePageSize').returns(10);
-        stub(Tasks, 'buildRequestFromSkus').withArgs(flux, pastPurchaseSkus).returns(pastPurchasesFromSkus);
+        stub(RecommendationsTasks, 'buildRequestFromSkus').withArgs(flux, pastPurchaseSkus).returns(pastPurchasesFromSkus);
         stub(RequestBuilders.pastPurchaseProductsRequest, 'composeRequest').withArgs(state, {
           pageSize,
           skip: 0,
           ...pastPurchasesFromSkus,
         }).returns(request);
 
-        const task = Tasks.fetchMorePastPurchaseProducts(flux, action);
+        const task = RecommendationsTasks.fetchMorePastPurchaseProducts(flux, action);
 
         expect(task.next().value).to.eql(effects.select());
         expect(task.next(state).value).to.eql(effects.select(pastPurchaseSkusSelector));
@@ -492,10 +489,10 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
           }
         };
         const composeRequest = stub(RequestBuilders.pastPurchaseProductsRequest, 'composeRequest');
-        stub(Tasks, 'buildRequestFromSkus').returns(pastPurchaseFromSkus);
+        stub(RecommendationsTasks, 'buildRequestFromSkus').returns(pastPurchaseFromSkus);
         stub(Selectors, 'pastPurchaseProductsWithMetadata').returns([{ index: 13 }]);
 
-        const task = Tasks.fetchMorePastPurchaseProducts(flux, action);
+        const task = RecommendationsTasks.fetchMorePastPurchaseProducts(flux, action);
 
         task.next();
         task.next(state);
@@ -518,7 +515,7 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
           actions: { receiveMorePastPurchaseProducts }
         };
 
-        const task = Tasks.fetchMorePastPurchaseProducts(flux, <any>{});
+        const task = RecommendationsTasks.fetchMorePastPurchaseProducts(flux, <any>{});
 
         task.next();
         expect(task.throw(error).value).to.eql(effects.put(receiveMorePastPurchaseProductsAction));
@@ -535,7 +532,7 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         const action: any = { payload };
         const state = { a: 'b' };
 
-        const task = Tasks.fetchSaytPastPurchases(flux, action);
+        const task = RecommendationsTasks.fetchSaytPastPurchases(flux, action);
 
         expect(task.next().value).to.eql(effects.select());
         expect(task.next(state).value).to.eql(effects.select(Selectors.pastPurchases));
@@ -560,7 +557,7 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
           .withArgs(state, { query: payload }).returns(request);
         stub(Selectors, 'pastPurchases').returns(pastPurchaseSkus);
 
-        const task = Tasks.fetchSaytPastPurchases(flux, action);
+        const task = RecommendationsTasks.fetchSaytPastPurchases(flux, action);
 
         expect(task.next().value).to.eql(effects.select());
         expect(task.next(state).value).to.eql(effects.select(Selectors.pastPurchases));
@@ -583,7 +580,7 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         };
         const composeRequest = stub(RequestBuilders.autocompletePastPurchaseRequest, 'composeRequest');
 
-        const task = Tasks.fetchSaytPastPurchases(<any>{}, action);
+        const task = RecommendationsTasks.fetchSaytPastPurchases(<any>{}, action);
 
         task.next();
         task.next(state);
@@ -597,7 +594,7 @@ suite('recommendations saga', ({ expect, spy, stub }) => {
         const flux: any = { actions: { receiveSaytPastPurchases } };
         const action: any = { payload: {} };
 
-        const task = Tasks.fetchSaytPastPurchases(flux, action);
+        const task = RecommendationsTasks.fetchSaytPastPurchases(flux, action);
 
         task.next();
         expect(task.throw(error).value).to.eql(effects.put(receiveSaytPastPurchases(error)));

--- a/packages/@storefront/flux-capacitor/test/unit/core/sagas/refinements.ts
+++ b/packages/@storefront/flux-capacitor/test/unit/core/sagas/refinements.ts
@@ -5,7 +5,7 @@ import RecommendationsAdapter from '../../../../src/core/adapters/recommendation
 import Adapter from '../../../../src/core/adapters/refinements';
 import Events from '../../../../src/core/events';
 import { refinementsRequest } from '../../../../src/core/requests';
-import sagaCreator, { Tasks } from '../../../../src/core/sagas/refinements';
+import sagaCreator, { RefinementsTasks } from '../../../../src/core/sagas/refinements';
 import Requests from '../../../../src/core/sagas/requests';
 import Selectors from '../../../../src/core/selectors';
 import suite from '../../_suite';
@@ -19,7 +19,7 @@ suite('refinements saga', ({ expect, spy, stub }) => {
       const saga = sagaCreator(flux)();
 
       // tslint:disable-next-line max-line-length
-      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_MORE_REFINEMENTS, Tasks.fetchMoreRefinements, flux));
+      expect(saga.next().value).to.eql(effects.takeLatest(Actions.FETCH_MORE_REFINEMENTS, RefinementsTasks.fetchMoreRefinements, flux));
       saga.next();
     });
   });
@@ -59,7 +59,7 @@ suite('refinements saga', ({ expect, spy, stub }) => {
         stub(RecommendationsAdapter, 'sortAndPinNavigations')
           .withArgs([results.navigation], [], config).returns(results);
 
-        const task = Tasks.fetchMoreRefinements(flux, <any>{ payload: { navigationId } });
+        const task = RefinementsTasks.fetchMoreRefinements(flux, <any>{ payload: { navigationId } });
 
         expect(task.next().value).to.eql(effects.select());
         expect(task.next(state).value).to.eql(effects.select(Selectors.config));
@@ -81,7 +81,7 @@ suite('refinements saga', ({ expect, spy, stub }) => {
         };
         const composeRequest = stub(refinementsRequest, 'composeRequest');
 
-        const task = Tasks.fetchMoreRefinements(<any>{}, action);
+        const task = RefinementsTasks.fetchMoreRefinements(<any>{}, action);
 
         task.next();
         task.next(state);
@@ -95,7 +95,7 @@ suite('refinements saga', ({ expect, spy, stub }) => {
         const flux: any = {};
         const action = stub(utils, 'createAction').returns(receiveMoreRefinementsAction);
 
-        const task = Tasks.fetchMoreRefinements(flux, <any>{});
+        const task = RefinementsTasks.fetchMoreRefinements(flux, <any>{});
 
         task.next();
         expect(task.throw(error).value).to.eql(effects.put(receiveMoreRefinementsAction));

--- a/packages/@storefront/flux-capacitor/test/unit/core/sagas/requests.ts
+++ b/packages/@storefront/flux-capacitor/test/unit/core/sagas/requests.ts
@@ -1,13 +1,8 @@
 import * as effects from 'redux-saga/effects';
-import * as sinon from 'sinon';
-import Actions from '../../../../src/core/actions';
 import PastPurchasesAdapter from '../../../../src/core/adapters/past-purchases';
 import RecommendationsAdapter from '../../../../src/core/adapters/recommendations';
-import Events from '../../../../src/core/events';
 import RequestHelpers from '../../../../src/core/requests/utils';
-import sagaCreator, { Tasks } from '../../../../src/core/sagas/product-details';
 import Requests from '../../../../src/core/sagas/requests';
-import Selectors from '../../../../src/core/selectors';
 import * as utils from '../../../../src/core/utils';
 import suite from '../../_suite';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -332,13 +332,6 @@
   dependencies:
     redux "^3.6.0"
 
-"@types/redux-persist@^4.3.1":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@types/redux-persist/-/redux-persist-4.3.1.tgz#aa4c876859e0bea5155e5f7980e5b8c4699dc2e6"
-  integrity sha1-qkyHaFngvqUVXl95gOW4xGmdwuY=
-  dependencies:
-    redux-persist "*"
-
 "@types/riot@^3.6.1":
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/@types/riot/-/riot-3.6.1.tgz#955cacc770b57e0c7c78dc9855db92a86ecfe5de"
@@ -5139,11 +5132,6 @@ redux-logger@^3.0.6:
   integrity sha1-91VZZvMJjzyIYExEnPC69XeCdL8=
   dependencies:
     deep-diff "^0.3.5"
-
-redux-persist@*:
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-5.10.0.tgz#5d8d802c5571e55924efc1c3a9b23575283be62b"
-  integrity sha512-sSJAzNq7zka3qVHKce1hbvqf0Vf5DuTVm7dr4GtsqQVOexnrvbV47RWFiPxQ8fscnyiuWyD2O92DOxPl0tGCRg==
 
 redux-persist@5.4.0:
   version "5.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -332,6 +332,13 @@
   dependencies:
     redux "^3.6.0"
 
+"@types/redux-persist@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@types/redux-persist/-/redux-persist-4.3.1.tgz#aa4c876859e0bea5155e5f7980e5b8c4699dc2e6"
+  integrity sha1-qkyHaFngvqUVXl95gOW4xGmdwuY=
+  dependencies:
+    redux-persist "*"
+
 "@types/riot@^3.6.1":
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/@types/riot/-/riot-3.6.1.tgz#955cacc770b57e0c7c78dc9855db92a86ecfe5de"
@@ -5132,6 +5139,11 @@ redux-logger@^3.0.6:
   integrity sha1-91VZZvMJjzyIYExEnPC69XeCdL8=
   dependencies:
     deep-diff "^0.3.5"
+
+redux-persist@*:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-5.10.0.tgz#5d8d802c5571e55924efc1c3a9b23575283be62b"
+  integrity sha512-sSJAzNq7zka3qVHKce1hbvqf0Vf5DuTVm7dr4GtsqQVOexnrvbV47RWFiPxQ8fscnyiuWyD2O92DOxPl0tGCRg==
 
 redux-persist@5.4.0:
   version "5.4.0"


### PR DESCRIPTION
Also did a bunch of cleanup (removing unused imports, renaming unused arguments, etc).