### PR TITLE
Stop updating canary in the cdn release

### DIFF
--- a/scripts/publish-cdn.sh
+++ b/scripts/publish-cdn.sh
@@ -110,7 +110,7 @@ versions_file="${tmpdir}/versions"
 
 # Copy bundle
 copy_artifact "$version"
-copy_artifact 'canary'
+#copy_artifact 'canary'
 
 # Commit and push bundle
 if [[ -n "$CI" ]]; then


### PR DESCRIPTION
CVS is pointing to our canary file, so we need to stop updating it until
they are prepared to release a new version of EZR. Until then we are not
updating canary.