### PR TITLE
SF-1246: Use the CircleCI build number for workflow identification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,12 +63,13 @@ jobs:
   ## Initialization jobs
 
   ### generate_cache_key_file
-  ### Stores the current time in a file to use in unique cache keys for this workflow.
+  ### Stores the current build number in a file to use in unique cache keys and branch names for this workflow.
+  ### The build number is guaranteed to be unique per build per project and is suitable for use as an identifier.
   generate_cache_key_file:
     <<: *image
     working_directory: ~/
     steps:
-      - run: date +%s > workflow-start
+      - run: echo "$CIRCLE_BUILD_NUM" > workflow-start
       - persist_to_workspace:
           root: ~/
           paths:


### PR DESCRIPTION
The build number is guaranteed to be unique per project and strictly monotonically increasing, so there should be no collisions.