### PR TITLE
SF-1264: Navigation component should not render hidden content

### DIFF
--- a/packages/@storefront/navigation/CHANGELOG.md
+++ b/packages/@storefront/navigation/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] [patch]
+### Changed
+- SF-1264: Add an `if` to hide the navigation display component when state is inactive.
+  - Modify `gb-navigation-header` to trigger icon image update on prop changes.
+
 ## [2.1.0] - 2019-01-18
 ### Changed
 - Update `@storefront/core` to 2.1.0.

--- a/packages/@storefront/navigation/src/navigation-display/index.html
+++ b/packages/@storefront/navigation/src/navigation-display/index.html
@@ -1,4 +1,9 @@
 <yield>
   <gb-navigation-header _props="{headerProps()}"></gb-navigation-header>
-  <div data-is="gb-{state.display || 'value'}-refinement-controls" class="gb-refinement-controls {gb-active: state.isActive}" navigation="{state.navigation}"></div>
+  <div
+    data-is="gb-{state.display || 'value'}-refinement-controls"
+    class="gb-refinement-controls {gb-active: state.isActive}"
+    navigation="{state.navigation}"
+    if="{state.isActive}">
+  </div>
 </yield>

--- a/packages/@storefront/navigation/src/navigation-display/index.ts
+++ b/packages/@storefront/navigation/src/navigation-display/index.ts
@@ -93,7 +93,7 @@ class NavigationDisplay {
   onToggle = () =>
     this.actions.createComponentState(Tag.getMeta(this).name, this.props.field.value, {
       isActive: !this.state.isActive,
-    });
+    })
 }
 
 interface NavigationDisplay extends Tag<NavigationDisplay.Props, NavigationDisplay.State> {}

--- a/packages/@storefront/navigation/src/navigation-header/index.html
+++ b/packages/@storefront/navigation/src/navigation-header/index.html
@@ -1,6 +1,6 @@
 <yield>
   <h4 class="gb-navigation__label">{props.label}</h4>
-  <gb-button if="{props.collapse}" class="gb-navigation__collapse-toggle" on-click="{props.onToggle}">
-    <gb-icon image="{parent.toggleIcon()}"></gb-icon>
+  <gb-button if="{props.collapse}" class="gb-navigation__collapse-toggle" on-click="{props.onToggle}" image="{state.icon}">
+    <gb-icon image="{props.image}"></gb-icon>
   </gb-button>
 </yield>

--- a/packages/@storefront/navigation/src/navigation-header/index.ts
+++ b/packages/@storefront/navigation/src/navigation-header/index.ts
@@ -9,15 +9,15 @@ class NavigationHeader {
   };
 
   init() {
-    this.setIcon(this.toggleIcon());
+    this.setIcon();
   }
 
   onUpdate() {
-    this.setIcon(this.toggleIcon());
+    this.setIcon();
   }
 
-  setIcon(icon: string) {
-    this.state = { icon };
+  setIcon() {
+    this.state = { icon: this.toggleIcon() };
   }
 
   toggleIcon() {
@@ -26,7 +26,7 @@ class NavigationHeader {
   }
 }
 
-interface NavigationHeader extends Tag<NavigationHeader.Props> {}
+interface NavigationHeader extends Tag<NavigationHeader.Props, NavigationHeader.State> {}
 namespace NavigationHeader {
   export interface Props extends Tag.Props {
     icons: NavigationDisplay.Icons;

--- a/packages/@storefront/navigation/src/navigation-header/index.ts
+++ b/packages/@storefront/navigation/src/navigation-header/index.ts
@@ -8,6 +8,18 @@ class NavigationHeader {
     icons: {},
   };
 
+  init() {
+    this.setIcon(this.toggleIcon());
+  }
+
+  onUpdate() {
+    this.setIcon(this.toggleIcon());
+  }
+
+  setIcon(icon: string) {
+    this.state = { icon };
+  }
+
   toggleIcon() {
     const { isActive, icons } = this.props;
     return isActive ? icons.toggleOpen : icons.toggleClosed;
@@ -22,6 +34,10 @@ namespace NavigationHeader {
     isActive: boolean;
     collapse: boolean;
     onToggle: () => void;
+  }
+
+  export interface State {
+    icon: string;
   }
 }
 

--- a/packages/@storefront/navigation/src/navigation-header/index.ts
+++ b/packages/@storefront/navigation/src/navigation-header/index.ts
@@ -17,7 +17,7 @@ class NavigationHeader {
   }
 
   setIcon() {
-    this.state = { icon: this.toggleIcon() };
+    this.state = { ...this.state, icon: this.toggleIcon() };
   }
 
   toggleIcon() {

--- a/packages/@storefront/navigation/test/unit/navigation-header.ts
+++ b/packages/@storefront/navigation/test/unit/navigation-header.ts
@@ -53,13 +53,13 @@ suite('NavigationHeader', ({ expect, spy, stub, itShouldProvideAlias }) => {
     const toggleClosed = 'closed';
     const icons = { toggleOpen, toggleClosed };
 
-    it('should return the toggleOpen state when isActive is true', () => {
+    it('should return the toggleOpen icon when isActive is true', () => {
       navigationHeader.props = <any>{ isActive: true, icons };
 
       expect(navigationHeader.toggleIcon()).to.eq(toggleOpen);
     });
 
-    it('should return the toggleClosed state when isActive is false', () => {
+    it('should return the toggleClosed icon when isActive is false', () => {
       navigationHeader.props = <any>{ isActive: false, icons };
 
       expect(navigationHeader.toggleIcon()).to.eq(toggleClosed);

--- a/packages/@storefront/navigation/test/unit/navigation-header.ts
+++ b/packages/@storefront/navigation/test/unit/navigation-header.ts
@@ -15,4 +15,54 @@ suite('NavigationHeader', ({ expect, spy, stub, itShouldProvideAlias }) => {
       });
     });
   });
+
+  describe('init()', () => {
+    it('should call setIcon', () => {
+      const setIcon = navigationHeader.setIcon = spy();
+
+      navigationHeader.init();
+
+      expect(setIcon).to.be.called;
+    });
+  });
+
+  describe('onUpdate()', () => {
+    it('should call setIcon', () => {
+      const setIcon = navigationHeader.setIcon = spy();
+
+      navigationHeader.onUpdate();
+
+      expect(setIcon).to.be.called;
+    });
+  });
+
+  describe('setIcon()', () => {
+    it('should set icon in state', () => {
+      const icon = 'icon';
+      const toggleIcon = navigationHeader.toggleIcon = spy(() => icon);
+
+      navigationHeader.setIcon();
+
+      expect(toggleIcon).to.be.called;
+      expect(navigationHeader.state.icon).to.eq(icon);
+    });
+  });
+
+  describe('toggleIcon()', () => {
+    const toggleOpen = 'open';
+    const toggleClosed = 'closed';
+    const icons = { toggleOpen, toggleClosed };
+
+    it('should return the toggleOpen state when isActive is true', () => {
+      navigationHeader.props = <any>{ isActive: true, icons };
+
+      expect(navigationHeader.toggleIcon()).to.eq(toggleOpen);
+    });
+
+    it('should return the toggleClosed state when isActive is false', () => {
+      navigationHeader.props = <any>{ isActive: false, icons };
+
+      expect(navigationHeader.toggleIcon()).to.eq(toggleClosed);
+    });
+  });
 });


### PR DESCRIPTION
I had to modify `navigationHeader` a bit because I noticed that the icon wasn't updating when the `shouldUpdate` mixin is enabled.