### PR TITLE
SF-1272: Pin version of CircleCI Node image to 11.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults:
   image: &image
     docker:
-      - image: circleci/node
+      - image: circleci/node:11.6.0
   yarn_cache: &yarn_cache
     key: yarn_cache-v{{ .Environment.CI_CACHE_VERSION }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
   build_final_cache_partial: &build_final_cache_partial


### PR DESCRIPTION
This pins the version of node to 11.6.0 and yarn 1.12.3. node 11.7.0 or yarn 1.13.0 causes nyc to report 0% coverage.

https://github.com/istanbuljs/nyc/issues/921
https://github.com/yarnpkg/yarn/issues/6746

circleci/node:11.6.0
Digest: sha256:1a3a10a092bdfa3d92d48850818a5526b5770a58592156f6f8e6a5f7d946ac43
Created 2019-01-18T00:14:29.784667795Z
NODE_VERSION=11.6.0
YARN_VERSION=1.12.3