### PR TITLE
SF-1209: Support other-origin single-product redirects

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "codecov": "^3.1.0",
     "cross-env": "^5.2.0",
     "css-loader": "^1.0.1",
+    "domexception": "^1.0.1",
     "dynamic-polyfill": "^1.1.0",
     "expose-loader": "^0.7.5",
     "html-loader": "^0.5.5",

--- a/packages/@storefront/core/CHANGELOG.md
+++ b/packages/@storefront/core/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] [patch]
+### Fixed
+- SF-1209: Other-origin single-product redirects no longer error.
+
 ## [2.5.0] - 2019-02-04
 ### Changed
 - Update `@storefront/flux-capacitor` to 1.71.0.

--- a/packages/@storefront/core/src/core/utils.ts
+++ b/packages/@storefront/core/src/core/utils.ts
@@ -13,6 +13,10 @@ export const WINDOW = () => window;
 
 const ARRAY_TO_DOT_NOTATION_REGEX = /\[(\d+)\]/g;
 
+export const DOMEXCEPTION_NAMES = {
+  SECURITY_ERROR: 'SecurityError',
+};
+
 export const KEYS = {
   DOWN: 'ArrowDown',
   ENTER: 'Enter',

--- a/packages/@storefront/core/src/services/url.ts
+++ b/packages/@storefront/core/src/services/url.ts
@@ -95,7 +95,14 @@ class UrlService extends BaseService<UrlService.Options> {
       try {
         return this.history.replaceState(data, title, url);
       } catch (e) {
-        return WINDOW().location.replace(url);
+        if (e.name === 'SecurityError') {
+          // If a SecurityError is thrown, the URL is probably not in the same origin.
+          // Hard-navigate to the URL instead.
+          return WINDOW().location.replace(url);
+        } else {
+          // Rethrow the error for all other cases to prevent infinite loops.
+          throw e;
+        }
       }
     };
   }

--- a/packages/@storefront/core/src/services/url.ts
+++ b/packages/@storefront/core/src/services/url.ts
@@ -84,7 +84,18 @@ class UrlService extends BaseService<UrlService.Options> {
         if (redirectFnResult) {
           return WINDOW().location.assign(redirectFnResult);
         } else {
-          return this.history.pushState(data, title, url);
+          try {
+            return this.history.pushState(data, title, url);
+          } catch (e) {
+            if (e.name === 'SecurityError') {
+              // if a SecurityError is thrown, the URL is probably not in the same origin
+              // hard-navigate to the URL instead
+              return WINDOW().location.assign(url);
+            } else {
+              // rethrow the error for all other cases to prevent infinite loops
+              throw e;
+            }
+          }
         }
       };
     }

--- a/packages/@storefront/core/src/services/url.ts
+++ b/packages/@storefront/core/src/services/url.ts
@@ -91,7 +91,13 @@ class UrlService extends BaseService<UrlService.Options> {
   }
 
   get replaceState() {
-    return this.history.replaceState;
+    return (data, title, url) => {
+      try {
+        return this.history.replaceState(data, title, url);
+      } catch (e) {
+        return WINDOW().location.replace(url);
+      }
+    };
   }
 
   get initialUrl() {

--- a/packages/@storefront/core/src/services/url.ts
+++ b/packages/@storefront/core/src/services/url.ts
@@ -1,7 +1,7 @@
 import { Store, STOREFRONT_APP_ID } from '@storefront/flux-capacitor';
 import { core, BaseService } from '../core/service';
 import UrlBeautifier from '../core/url-beautifier';
-import { WINDOW } from '../core/utils';
+import { WINDOW, DOMEXCEPTION_NAMES } from '../core/utils';
 import StoreFront from '../storefront';
 import Utils from './urlUtils';
 
@@ -87,7 +87,7 @@ class UrlService extends BaseService<UrlService.Options> {
           try {
             return this.history.pushState(data, title, url);
           } catch (e) {
-            if (e.name === 'SecurityError') {
+            if (e.name === DOMEXCEPTION_NAMES.SECURITY_ERROR) {
               // if a SecurityError is thrown, the URL is probably not in the same origin
               // hard-navigate to the URL instead
               return WINDOW().location.assign(url);
@@ -106,7 +106,7 @@ class UrlService extends BaseService<UrlService.Options> {
       try {
         return this.history.replaceState(data, title, url);
       } catch (e) {
-        if (e.name === 'SecurityError') {
+        if (e.name === DOMEXCEPTION_NAMES.SECURITY_ERROR) {
           // if a SecurityError is thrown, the URL is probably not in the same origin
           // hard-navigate to the URL instead
           return WINDOW().location.replace(url);

--- a/packages/@storefront/core/src/services/url.ts
+++ b/packages/@storefront/core/src/services/url.ts
@@ -1,7 +1,7 @@
 import { Store, STOREFRONT_APP_ID } from '@storefront/flux-capacitor';
 import { core, BaseService } from '../core/service';
 import UrlBeautifier from '../core/url-beautifier';
-import { WINDOW, DOMEXCEPTION_NAMES } from '../core/utils';
+import { DOMEXCEPTION_NAMES, WINDOW } from '../core/utils';
 import StoreFront from '../storefront';
 import Utils from './urlUtils';
 

--- a/packages/@storefront/core/src/services/url.ts
+++ b/packages/@storefront/core/src/services/url.ts
@@ -96,11 +96,11 @@ class UrlService extends BaseService<UrlService.Options> {
         return this.history.replaceState(data, title, url);
       } catch (e) {
         if (e.name === 'SecurityError') {
-          // If a SecurityError is thrown, the URL is probably not in the same origin.
-          // Hard-navigate to the URL instead.
+          // if a SecurityError is thrown, the URL is probably not in the same origin
+          // hard-navigate to the URL instead
           return WINDOW().location.replace(url);
         } else {
-          // Rethrow the error for all other cases to prevent infinite loops.
+          // rethrow the error for all other cases to prevent infinite loops
           throw e;
         }
       }

--- a/packages/@storefront/core/test/unit/services/url.ts
+++ b/packages/@storefront/core/test/unit/services/url.ts
@@ -229,7 +229,7 @@ suite('URL Service', ({ expect, spy, stub, itShouldBeCore, itShouldExtendBaseSer
     });
 
     it('should fall back to location.assign for only SecurityError', () => {
-      const pushState = () => { throw new DOMException('here be SecurityError', 'SecurityError'); };
+      const pushState = () => { throw new DOMException('here be SecurityError', CoreUtils.DOMEXCEPTION_NAMES.SECURITY_ERROR); };
       service['opts'] = <any>{ redirects: {} };
       service.history = <any>{ pushState };
 
@@ -265,7 +265,7 @@ suite('URL Service', ({ expect, spy, stub, itShouldBeCore, itShouldExtendBaseSer
     });
 
     it('should fall back to location.replace for only SecurityError', () => {
-      const replaceState = () => { throw new DOMException('here be SecurityError', 'SecurityError'); };
+      const replaceState = () => { throw new DOMException('here be SecurityError', CoreUtils.DOMEXCEPTION_NAMES.SECURITY_ERROR); };
       service.history = <any>{ replaceState };
 
       service.replaceState(data, title, url);

--- a/packages/@storefront/core/test/unit/services/url.ts
+++ b/packages/@storefront/core/test/unit/services/url.ts
@@ -227,12 +227,15 @@ suite('URL Service', ({ expect, spy, stub, itShouldBeCore, itShouldExtendBaseSer
 
   describe('get replaceState()', () => {
     it('should use the history replaceState', () => {
-      const replaceState = () => null;
+      const replaceState = spy();
+      const data = { a: 'b' };
+      const title = 'this website';
+      const url = 'www.example.com';
       service.history = <any>{ replaceState };
 
-      const result = service.replaceState;
+      service.replaceState(data, title, url);
 
-      expect(result).to.eq(replaceState);
+      expect(replaceState).to.be.calledWith(data, title, url);
     });
   });
 

--- a/packages/@storefront/core/test/unit/services/url.ts
+++ b/packages/@storefront/core/test/unit/services/url.ts
@@ -196,7 +196,7 @@ suite('URL Service', ({ expect, spy, stub, itShouldBeCore, itShouldExtendBaseSer
 
       service.pushState(null, null, url);
 
-      expect(assign).to.be.calledWith(redirectsResult);
+      expect(assign).to.be.calledWithExactly(redirectsResult);
     });
 
     it('should use the opts redirects if it is an object', () => {
@@ -209,7 +209,7 @@ suite('URL Service', ({ expect, spy, stub, itShouldBeCore, itShouldExtendBaseSer
 
       service.pushState(null, null, url);
 
-      expect(assign).to.be.calledWith(redirectsResult);
+      expect(assign).to.be.calledWithExactly(redirectsResult);
     });
 
     it('should use the history pushState if it exists', () => {
@@ -221,7 +221,7 @@ suite('URL Service', ({ expect, spy, stub, itShouldBeCore, itShouldExtendBaseSer
 
       service.pushState(data, title, url);
 
-      expect(pushState).to.be.calledWith(data, title, url);
+      expect(pushState).to.be.calledWithExactly(data, title, url);
     });
   });
 

--- a/packages/@storefront/core/test/unit/services/url.ts
+++ b/packages/@storefront/core/test/unit/services/url.ts
@@ -244,7 +244,7 @@ suite('URL Service', ({ expect, spy, stub, itShouldBeCore, itShouldExtendBaseSer
     });
 
     it('should fall back to location.replace for only SecurityError', () => {
-      const replaceState = () => { throw new DOMException('here be SecurityError', 'SecurityError') };
+      const replaceState = () => { throw new DOMException('here be SecurityError', 'SecurityError'); };
       service.history = <any>{ replaceState };
 
       service.replaceState(data, title, url);
@@ -254,7 +254,7 @@ suite('URL Service', ({ expect, spy, stub, itShouldBeCore, itShouldExtendBaseSer
 
     it('should rethrow any exception other than SecurityError', () => {
       const error = new Error('not a SecurityError');
-      const replaceState = () => { throw error };
+      const replaceState = () => { throw error; };
       service.history = <any>{ replaceState };
 
       const throwReplace = () => service.replaceState(data, title, url);

--- a/packages/@storefront/core/test/unit/services/url.ts
+++ b/packages/@storefront/core/test/unit/services/url.ts
@@ -1,4 +1,5 @@
 import { STOREFRONT_APP_ID } from '@storefront/flux-capacitor';
+import * as DOMException from 'domexception';
 import * as UrlBeautifier from '../../../src/core/url-beautifier';
 import * as CoreUtils from '../../../src/core/utils';
 import Service from '../../../src/services/url';
@@ -242,13 +243,23 @@ suite('URL Service', ({ expect, spy, stub, itShouldBeCore, itShouldExtendBaseSer
       expect(replaceState).to.be.calledWithExactly(data, title, url);
     });
 
-    it('should fall back to location.replace', () => {
-      const replaceState = () => { throw new Error('fail'); };
+    it('should fall back to location.replace for only SecurityError', () => {
+      const replaceState = () => { throw new DOMException('here be SecurityError', 'SecurityError') };
       service.history = <any>{ replaceState };
 
       service.replaceState(data, title, url);
 
       expect(replace).to.be.calledWithExactly(url);
+    });
+
+    it('should rethrow any exception other than SecurityError', () => {
+      const error = new Error('not a SecurityError');
+      const replaceState = () => { throw error };
+      service.history = <any>{ replaceState };
+
+      const throwReplace = () => service.replaceState(data, title, url);
+
+      expect(throwReplace).to.throw(error);
     });
   });
 

--- a/packages/@storefront/core/test/unit/services/url.ts
+++ b/packages/@storefront/core/test/unit/services/url.ts
@@ -229,7 +229,9 @@ suite('URL Service', ({ expect, spy, stub, itShouldBeCore, itShouldExtendBaseSer
     });
 
     it('should fall back to location.assign for only SecurityError', () => {
-      const pushState = () => { throw new DOMException('here be SecurityError', CoreUtils.DOMEXCEPTION_NAMES.SECURITY_ERROR); };
+      const pushState = () => {
+        throw new DOMException('here be SecurityError', CoreUtils.DOMEXCEPTION_NAMES.SECURITY_ERROR);
+      };
       service['opts'] = <any>{ redirects: {} };
       service.history = <any>{ pushState };
 
@@ -265,7 +267,9 @@ suite('URL Service', ({ expect, spy, stub, itShouldBeCore, itShouldExtendBaseSer
     });
 
     it('should fall back to location.replace for only SecurityError', () => {
-      const replaceState = () => { throw new DOMException('here be SecurityError', CoreUtils.DOMEXCEPTION_NAMES.SECURITY_ERROR); };
+      const replaceState = () => {
+        throw new DOMException('here be SecurityError',CoreUtils.DOMEXCEPTION_NAMES.SECURITY_ERROR);
+      };
       service.history = <any>{ replaceState };
 
       service.replaceState(data, title, url);

--- a/packages/@storefront/core/test/unit/services/url.ts
+++ b/packages/@storefront/core/test/unit/services/url.ts
@@ -186,7 +186,6 @@ suite('URL Service', ({ expect, spy, stub, itShouldBeCore, itShouldExtendBaseSer
     const title = 'this website';
     const url = 'www.example.com';
 
-
     it('should use the opts urlHandler if it is a function', () => {
       const urlHandler = spy();
       service['opts'] = <any>{ urlHandler };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1847,6 +1847,13 @@ domain-browser@^1.1.1:
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
   integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
 
+domexception@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
+  integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
+  dependencies:
+    webidl-conversions "^4.0.2"
+
 dot-prop@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
@@ -6534,6 +6541,11 @@ watchpack@^1.4.0:
     chokidar "^2.0.2"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+
+webidl-conversions@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+  integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
 webpack-bundle-analyzer@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
Fall back to location.replace when a SecurityError is thrown.