### PR TITLE
SF-970: Remove unnecessary update on mount for sayt component

### DIFF
--- a/packages/@storefront/sayt/CHANGELOG.md
+++ b/packages/@storefront/sayt/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] [patch]
+### Fixed
+- SF-970: Prevent unnecessary update of the `Sayt` component on mount.
+
 ## [2.8.1] - 2019-04-04
 ### Fixed
 - SF-1296: Resolved memory leak issue with autocomplete component.

--- a/packages/@storefront/sayt/src/sayt/index.ts
+++ b/packages/@storefront/sayt/src/sayt/index.ts
@@ -13,7 +13,7 @@ class Sayt {
     },
   };
   state: Sayt.State = {
-    isActive: true,
+    isActive: false,
     showRecommendations: false,
     showProducts: true,
     highlight: (value, replacement) => {
@@ -35,8 +35,8 @@ class Sayt {
   }
 
   onMount() {
-    // initialize as active to initialize child component
-    this.setInactive();
+    // initialize listener for AUTOCOMPLETE_QUERY_UPDATED
+    this.unregisterClickAwayHandler();
   }
 
   setActive = () => !this.state.isActive && this.set({ isActive: true });

--- a/packages/@storefront/sayt/test/unit/sayt.ts
+++ b/packages/@storefront/sayt/test/unit/sayt.ts
@@ -19,7 +19,7 @@ suite('Sayt', ({ expect, spy, stub, itShouldBeConfigurable, itShouldProvideAlias
 
     describe('state', () => {
       it('should set initial value', () => {
-        expect(sayt.state.isActive).to.be.true;
+        expect(sayt.state.isActive).to.be.false;
         expect(sayt.state.showRecommendations).to.be.false;
         expect(sayt.state.showProducts).to.be.true;
       });
@@ -128,12 +128,12 @@ suite('Sayt', ({ expect, spy, stub, itShouldBeConfigurable, itShouldProvideAlias
   });
 
   describe('onMount()', () => {
-    it('should inactivate sayt', () => {
-      const setInactive = (sayt.setInactive = spy());
+    it('should call unregisterClickAwayHandler', () => {
+      const unregisterClickAwayHandler = sayt.unregisterClickAwayHandler = spy();
 
       sayt.onMount();
 
-      expect(setInactive).to.be.called;
+      expect(unregisterClickAwayHandler).to.be.called;
     });
   });
 


### PR DESCRIPTION
Being active by default and then becoming inactive on mount may have been necessary when `sayt` had used `if` instead of `show` to allow the inner components to be instantiated. It is no longer necessary because `sayt` uses `show`, which allows the inner components to instantiate while still be hidden from view.